### PR TITLE
Moved BaseTriggerHandler import into dispatch method and fixed Event() instantiation

### DIFF
--- a/geomet_weather/trigger/event.py
+++ b/geomet_weather/trigger/event.py
@@ -17,8 +17,6 @@
 #
 ###############################################################################
 
-from msc_pygeoapi.trigger import BaseTriggerHandler
-
 
 class Event(object):
     """core event"""
@@ -36,6 +34,7 @@ class Event(object):
         :returns: `bool` of dispatch result
         """
         try:
+            from geomet_weather.trigger.base import BaseTriggerHandler
             filepath = parent.msg.local_file
             parent.logger.debug('Filepath: {}'.format(filepath))
             handler = BaseTriggerHandler(filepath)
@@ -50,5 +49,5 @@ class Event(object):
         return '<Event>'
 
 
-event = Event()
+event = Event(self)
 self.on_message = event.dispatch


### PR DESCRIPTION
I noticed a few issues with event.py when I tried getting it to work with sarracenia.

I modified the import statement to reflect the current project structure (it was previously importing from `msc_pygeoapi.trigger`) and moved the import statement into the dispatch method. When trying to start the sr_subscribe with the import statement at the Event class level, sarracenia was complaining with the following message in the log:

`2019-06-21 11:52:42,802 [WARNING] name 'BaseTriggerHandler' is not defined`

Moving it into the try block of the dispatch method resolves this issue. I believe this is related to [import issues in sarracenia](https://github.com/MetPX/sarracenia/blob/master/doc/Prog.rst#why-doesn-t-import-work).

We were also missing the `self` argument when creating the Event() instance.

With these adjustments, I was able to get sr_subscribe working properly and calling the event.py script without any errors!