### PR TITLE
added check to not count in Redis if the feature is already in ES

### DIFF
--- a/geomet_data_registry/layer/base.py
+++ b/geomet_data_registry/layer/base.py
@@ -76,7 +76,10 @@ class BaseLayer(object):
 
             item_dict = self.layer2dict(item)
 
-            if item['expected_count'] is not None:
+            LOGGER.debug('Adding to tileindex')
+            r = self.tileindex.add(item['identifier'], item_dict)
+
+            if item['expected_count'] is not None and r['result'] == 'created':
 
                 layer_count_key = '{}_{}_count'.format(
                     item_dict['properties']['layer'], self.model_run)
@@ -104,9 +107,6 @@ class BaseLayer(object):
                             item_dict['properties']['layer'], mr)
                         if layer_count_key_reset != layer_count_key:
                             self.store.set(layer_count_key_reset, 0)
-
-            LOGGER.debug('Adding to tileindex')
-            self.tileindex.add(item['identifier'], item_dict)
 
         return True
 

--- a/geomet_data_registry/tileindex/elasticsearch_.py
+++ b/geomet_data_registry/tileindex/elasticsearch_.py
@@ -189,8 +189,9 @@ class ElasticsearchTileIndex(BaseTileIndex):
             # immediately after in support of tracking performance (kind of
             # ironic eh?).
             # TODO: update using asyncio or multiprocessing
-            self.es.index(index=self.name, id=identifier, body=data,
-                          refresh='wait_for')
+            r = self.es.index(index=self.name, id=identifier, body=data,
+                              refresh='wait_for')
+            return r
         except Exception as err:
             LOGGER.exception('Error indexing {}: {}'.format(identifier, err))
             return False


### PR DESCRIPTION
added check to not count in Redis if the feature is already in ES
No new requests to ES is required. 
We now need to insert to ES before doing the count, which does not cause any logical issue AFAIK.