### PR TITLE
fixed query dictionary creation used to create the query key in es_body_query

### DIFF
--- a/geomet_data_registry/tileindex/elasticsearch_.py
+++ b/geomet_data_registry/tileindex/elasticsearch_.py
@@ -235,12 +235,13 @@ class ElasticsearchTileIndex(BaseTileIndex):
         LOGGER.info('query dict: {}'.format(query_dict))
         LOGGER.info('update dict: {}'.format(update_dict))
 
-        query_dict2 = {}
         for key, value in query_dict.items():
             property_name = 'properties.{}.raw'.format(key)
-            query_dict2['match'] = {
-                property_name: {
-                    'query': value
+            es_query_body['query'] = {
+                'match': {
+                    property_name: {
+                        'query': value
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes issue where all items' `register_datetime` property value were update due to the `query` key not being passed on correctly to the `es_query_body` variable.

As reported in #19 .

This fix was tested using the `add-file` flag with the CLI tool on two separate data files each of which conserved its own `register_datetime` value when updated.