### PR TITLE
Added intial REPS layer handler, changed ES update_by_query to wildcard to allow for VRT stored in filepath

### DIFF
--- a/geomet_data_registry/handler/core.py
+++ b/geomet_data_registry/handler/core.py
@@ -28,7 +28,8 @@ LOGGER = logging.getLogger(__name__)
 DATASET_HANDLERS = {
     'CMC_glb': 'ModelGemGlobal',
     'RADAR_COMPOSITE_1KM': 'Radar1km',
-    'cansips': 'CanSIPS'
+    'cansips': 'CanSIPS',
+    'reps': 'REPS'
 }
 
 
@@ -83,7 +84,7 @@ class CoreHandler(BaseHandler):
                 self.layer_plugin.register_datetime = register_datetime_
 
                 query_dict = {
-                    'filepath': self.layer_plugin.filepath
+                    'filepath': '*{}*'.format(self.layer_plugin.filepath)
                 }
                 update_dict = {
                     'register_datetime': register_datetime_

--- a/geomet_data_registry/layer/cansips.py
+++ b/geomet_data_registry/layer/cansips.py
@@ -122,7 +122,7 @@ class CansipsLayer(BaseLayer):
                 <SourceBand>{}</SourceBand>
             </ComplexSource>
         </VRTRasterBand>
-    </VRTDataset>'''.format(filepath, band)
+    </VRTDataset>'''.format(filepath, band).replace('\n', '')
 
             feature_dict = {
                 'layer_name': layer_name,

--- a/geomet_data_registry/layer/reps.py
+++ b/geomet_data_registry/layer/reps.py
@@ -1,0 +1,151 @@
+###############################################################################
+#
+# Copyright (C) 2019 Louis-Philippe Rousseau-Lambert
+# Copyright (C) 2019 Etienne Pelletier
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+from datetime import datetime, timedelta
+import json
+import logging
+import os
+from parse import parse
+import re
+
+from geomet_data_registry.layer.base import BaseLayer
+
+LOGGER = logging.getLogger(__name__)
+
+
+class RepsLayer(BaseLayer):
+    """REPS layer"""
+
+    def __init__(self, provider_def):
+        """
+        Initialize object
+
+        :param provider_def: provider definition dict
+
+        :returns: `geomet_data_registry.layer.reps.REPSLayer`  # noqa
+        """
+
+        provider_def = {'name': 'reps'}
+        self.type = None
+        self.bands = None
+
+        BaseLayer.__init__(self, provider_def)
+
+    def identify(self, filepath):
+        """
+        Identifies a file of the layer
+
+        :param filepath: filepath from AMQP
+
+        :returns: `list` of file properties
+        """
+
+        self.filepath = filepath
+        self.file_creation_datetime = datetime.fromtimestamp(
+                os.path.getmtime(filepath))
+        self.model = 'reps'
+
+        LOGGER.debug('Loading model information from store')
+        file_dict = json.loads(self.store.get(self.model))
+
+        if self.filepath.endswith('allmbrs.grib2'):
+            filename_pattern = file_dict[self.model]['member']['filename_pattern']  # noqa
+            self.type = 'member'
+        elif self.filepath.endswith('all-products.grib2'):
+            filename_pattern = file_dict[self.model]['product']['filename_pattern']  # noqa
+            self.type = 'product'
+
+        tmp = parse(filename_pattern, os.path.basename(filepath))
+
+        file_pattern_info = {
+            'wx_variable': tmp.named['wx_variable'],
+            'time_': tmp.named['YYYYMMDD_model_run'],
+            'fh': tmp.named['forecast_hour']
+        }
+
+        LOGGER.debug('Defining the different file properties')
+        self.wx_variable = file_pattern_info['wx_variable']
+        weather_var = file_dict[self.model][self.type]['variable'][self.wx_variable]  # noqa
+
+        time_format = '%Y%m%d%H'
+        date_ = datetime.strptime(file_pattern_info['time_'], time_format)
+        reference_datetime = date_
+        self.model_run = '{}Z'.format(date_.strftime('%H'))
+        forecast_hour_datetime = date_ + \
+            timedelta(hours=int(file_pattern_info['fh']))
+
+        if self.type == 'member':
+            self.bands = file_dict[self.model]['member']['bands']
+        elif self.type == 'product':
+            self.bands = weather_var['bands']
+
+        for band in self.bands.keys():
+            vrt = '''\
+<VRTDataset rasterXSize="145" rasterYSize="73">
+    <SRS>'+proj=stere +lat_0=90 +lat_ts=60 +lon_0=250 +k=90 +x_0=0 +y_0=0 +a=6371229 +b=6371229 +units=m +no_defs'</SRS>
+    <GeoTransform> -4.4174117578025218e+06,  1.5000000000000000e+04,  0.0000000000000000e+00,  4.5777534875770006e+05,  0.0000000000000000e+00, -1.5000000000000000e+04</GeoTransform>
+    <VRTRasterBand dataType="Float64" band="1">
+        <ComplexSource>
+            <SourceFilename>{}</SourceFilename>
+            <SourceBand>{}</SourceBand>
+        </ComplexSource>
+    </VRTRasterBand>
+</VRTDataset>'''.format(self.filepath, band).replace('\n', '')  # noqa
+
+            elevation = weather_var['elevation']
+            time_format = '%Y-%m-%dT%H:%M:%SZ'
+            str_mr = re.sub('[^0-9]',
+                            '',
+                            reference_datetime.strftime(time_format))
+            str_fh = re.sub('[^0-9]',
+                            '',
+                            forecast_hour_datetime.strftime(time_format))
+
+            expected_count = file_dict[self.model][self.type]['variable'][self.wx_variable]['model_run'][self.model_run]['files_expected']  # noqa
+
+            for layer in weather_var['geomet_layers'].keys():
+
+                if self.type == 'member':
+                    member = self.bands[band]['member']
+                    layer_name = layer.format(self.bands[band]['member'])
+
+                elif self.type == 'product':
+                    member = None
+                    layer_name = layer.format(self.bands[band]['product'])
+
+                identifier = '{}-{}-{}'.format(layer_name, str_mr, str_fh)
+
+                feature_dict = {
+                    'layer_name': layer_name,
+                    'filepath': vrt,
+                    'identifier': identifier,
+                    'reference_datetime': reference_datetime,
+                    'forecast_hour_datetime': forecast_hour_datetime,
+                    'member': member,
+                    'elevation': elevation,
+                    'expected_count': expected_count
+                }
+
+                self.items.append(feature_dict)
+
+        return True
+
+    def __repr__(self):
+        return '<ModelREPSLayer> {}'.format(self.name)

--- a/geomet_data_registry/plugin.py
+++ b/geomet_data_registry/plugin.py
@@ -32,7 +32,8 @@ PLUGINS = {
     'layer': {
         'ModelGemGlobal': 'geomet_data_registry.layer.model_gem_global.ModelGemGlobalLayer',  # noqa
         'Radar1km': 'geomet_data_registry.layer.radar_1km.Radar1kmLayer',  # noqa
-        'CanSIPS': 'geomet_data_registry.layer.cansips.CansipsLayer'
+        'CanSIPS': 'geomet_data_registry.layer.cansips.CansipsLayer',  # noqa
+        'REPS': 'geomet_data_registry.layer.reps.RepsLayer'  # noqa
     }
 }
 

--- a/geomet_data_registry/tileindex/elasticsearch_.py
+++ b/geomet_data_registry/tileindex/elasticsearch_.py
@@ -89,9 +89,9 @@ INDEX_SETTINGS = {
                     'elevation': {
                         'type': 'text',
                         'fields': {
-                             'raw': {
-                                 'type': 'keyword'
-                             }
+                            'raw': {
+                                'type': 'keyword'
+                            }
                          }
                     },
                     'members': {
@@ -244,9 +244,9 @@ class ElasticsearchTileIndex(BaseTileIndex):
         for key, value in query_dict.items():
             property_name = 'properties.{}.raw'.format(key)
             es_query_body['query'] = {
-                'match': {
+                'wildcard': {
                     property_name: {
-                        'query': value
+                        'wildcard': value
                     }
                 }
             }


### PR DESCRIPTION
Initial commit for the REPS handler. I've tested it with both REPS products and members via the CLI.

Another change in this MR is the way we do the update_by_query in ES. We previously used a `match` query to match the entire filename in order to update the register_datetime property of a entry in ES. This has been changed to `wildcard` query  in order to capture cases where the filepath contains the entire VRT XML. The wildcard query returns documents in the ES index that *contain* the filepath in the document's file property. I have tested this change with both the GDPS handler and the REPS handler. Would like to know your thoughts on a better approach if there is one!