### PR TITLE
Added graceful error for when no key or config file passed to store set command

### DIFF
--- a/geomet_data_registry/store/__init__.py
+++ b/geomet_data_registry/store/__init__.py
@@ -90,6 +90,9 @@ def teardown(ctx, group=None):
 def set_key(ctx, key, config):
     """populate store"""
 
+    if all([key is None, config is None]):
+        raise click.ClickException('Missing --key/-k or --config/-c option')
+
     provider_def = {
         'type': STORE_TYPE,
         'url': STORE_URL


### PR DESCRIPTION
Added a graceful error for when no flags were passed to `geomet-data-registry store set` instead of producing a `TypeError` if no flags were given.