### PR TITLE
Added missing self.filepath variable

### DIFF
--- a/geomet_data_registry/layer/radar_1km.py
+++ b/geomet_data_registry/layer/radar_1km.py
@@ -55,7 +55,8 @@ class Radar1kmLayer(BaseLayer):
         """
 
         self.model = 'radar'
-
+        self.filepath = filepath    
+    
         LOGGER.debug('Loading model information from store')
         file_dict = json.loads(self.store.get_key(self.model))
 


### PR DESCRIPTION
Fixes issue #42.

We weren't setting `self.filepath` in the RADAR handler and so when updating the document in ES to add the `register_datetime` property, self.filepath was `None`.

Example of erroneous query:
```
{'query': {'wildcard': {'properties.filepath.raw': {'wildcard': '*None*'}}}, 'script': {'source': 'ctx._source.properties.register_datetime = "2019-09-26T13:06:08.995528"'}}
```

This sets the self.filepath variable in the radar layer handler and populates the query_dict with the right filepath.

Query after fix:

```
 {'query': {'wildcard': {'properties.filepath.raw': {'wildcard': '*/data-san/geomet/feeds/local/RADAR/1KM/MMHR/201909261150_RADAR_COMPOSITE_1KM_MMHR.tif*'}}}, 'script': {'source': 'ctx._source.properties.register_datetime = "2019-09-26T13:15:45.574624"'}}
```