### PR TITLE
Add ES ingest pipeline to calculate file registration time on ES side

### DIFF
--- a/geomet_data_registry/handler/core.py
+++ b/geomet_data_registry/handler/core.py
@@ -77,21 +77,7 @@ class CoreHandler(BaseHandler):
             self.layer_plugin.identify_datetime = datetime.now().isoformat()
 
             LOGGER.debug('Registering file')
-            register_status = self.layer_plugin.register()
-
-            if register_status:
-                register_datetime_ = datetime.now()
-                self.layer_plugin.register_datetime = register_datetime_
-
-                query_dict = {
-                    'filepath': '*{}*'.format(self.layer_plugin.filepath)
-                }
-                update_dict = {
-                    'register_datetime': register_datetime_
-                }
-
-                self.layer_plugin.tileindex.update_by_query(
-                    query_dict, update_dict)
+            self.layer_plugin.register()
 
         return True
 


### PR DESCRIPTION
Adds an ES ingest pipeline to calculate file registration on the Elasticsearch side. It is automatically created when the tileindex is setup and removed during teardown.

This change seems to significant increase performance and speed while indexing files (see #45 for details). I have tested the changes with the CLI tool for entire model runs (`geomet-data-registry data add -d <model_run>` and the result are consistent.

We'll have to test this with a live AMQP feed next.