### PR TITLE
Added handling for when interval is PT0H

### DIFF
--- a/geomet_data_registry/layer/model_gem_global.py
+++ b/geomet_data_registry/layer/model_gem_global.py
@@ -111,19 +111,20 @@ class ModelGemGlobalLayer(BaseLayer):
             interval = re.sub('[^0-9]', '', interval)
 
             fh = file_pattern_info['fh']
-            if int(fh) in range(int(begin), int(end), int(interval)):
-                feature_dict = {
-                    'layer_name': layer_name,
-                    'filepath': filepath,
-                    'identifier': identifier,
-                    'reference_datetime': reference_datetime,
-                    'forecast_hour_datetime': forecast_hour_datetime,
-                    'member': member,
-                    'model': self.model,
-                    'elevation': elevation,
-                    'expected_count': expected_count
-                }
 
+            feature_dict = {
+                'layer_name': layer_name,
+                'filepath': filepath,
+                'identifier': identifier,
+                'reference_datetime': reference_datetime,
+                'forecast_hour_datetime': forecast_hour_datetime,
+                'member': member,
+                'model': self.model,
+                'elevation': elevation,
+                'expected_count': expected_count
+            }
+
+            if (int(fh) == 0 and int(interval) == 0) or (int(fh) in range(int(begin), int(end), int(interval))):
                 self.items.append(feature_dict)
 
         return True


### PR DESCRIPTION
Fixes #48.

In situations where no time interval is defined for a given GDPS layer (PT0H), the `layers/model_gem_global.py` layer handler would error out due to the `range` function being called with a a step of 0 (see [L114](https://github.com/ECCC-MSC/geomet-data-registry/compare/master...Dukestep:gdps-pt0h-interval-fix?expand=1#diff-5770a3fccda74a8fe7a62c1ef12135cbL114)).

Tested problematic layers with geomet-data-registry CLI tool to confirm the fix.

cc @RousseauLambertLP 