### PR TITLE
Remove raising LayerError when variable not found

### DIFF
--- a/geomet_data_registry/layer/cansips.py
+++ b/geomet_data_registry/layer/cansips.py
@@ -81,8 +81,8 @@ class CansipsLayer(BaseLayer):
         if self.wx_variable not in file_dict[self.model]['variable']:
             msg = 'Variable "{}" not in ' \
                   'configuration file'.format(self.wx_variable)
-            LOGGER.exception(msg)
-            raise LayerError(msg)
+            LOGGER.warning(msg)
+            return False
 
         weather_var = file_dict[self.model]['variable'][self.wx_variable]
 

--- a/geomet_data_registry/layer/model_gem_global.py
+++ b/geomet_data_registry/layer/model_gem_global.py
@@ -78,8 +78,8 @@ class ModelGemGlobalLayer(BaseLayer):
         if self.wx_variable not in file_dict[self.model]['variable']:
             msg = 'Variable "{}" not in ' \
                   'configuration file'.format(self.wx_variable)
-            LOGGER.exception(msg)
-            raise LayerError(msg)
+            LOGGER.warning(msg)
+            return False
 
         runs = file_dict[self.model]['variable'][self.wx_variable]['model_run']
         self.model_run_list = list(runs.keys())

--- a/geomet_data_registry/layer/radar_1km.py
+++ b/geomet_data_registry/layer/radar_1km.py
@@ -75,8 +75,8 @@ class Radar1kmLayer(BaseLayer):
         if self.wx_variable not in file_dict[self.model]['variable']:
             msg = 'Variable "{}" not in ' \
                   'configuration file'.format(self.wx_variable)
-            LOGGER.exception(msg)
-            raise LayerError(msg)
+            LOGGER.warning(msg)
+            return False
 
         time_format = '%Y%m%d%H%M'
         date_ = datetime.strptime(file_pattern_info['time_'], time_format)

--- a/geomet_data_registry/layer/reps.py
+++ b/geomet_data_registry/layer/reps.py
@@ -87,8 +87,8 @@ class RepsLayer(BaseLayer):
         if self.wx_variable not in var_path:
             msg = 'Variable "{}" not in ' \
                   'configuration file'.format(self.wx_variable)
-            LOGGER.exception(msg)
-            raise LayerError(msg)
+            LOGGER.warning(msg)
+            return False
 
         weather_var = file_dict[self.model][self.type]['variable'][self.wx_variable]  # noqa
 


### PR DESCRIPTION
Raising a LayerError when a certain variable was not found was preventing us to load entire directories with the CLI tool (`geomet-data-registry data add -d <path_to_dir>`).

This approach still logs a warning to the logger but instead of raising a LayerError, the `identify` method returns `False` effectively ending the identify process without terminating the code.

Fixes #47.