### PR TITLE
Added Zulu designator 'Z' to all datetimes and modified ES mapping to expect this format

### DIFF
--- a/geomet_data_registry/handler/core.py
+++ b/geomet_data_registry/handler/core.py
@@ -22,7 +22,7 @@ import logging
 
 from geomet_data_registry.plugin import load_plugin
 from geomet_data_registry.handler.base import BaseHandler
-
+from geomet_data_registry.util import get_today_and_now
 LOGGER = logging.getLogger(__name__)
 
 DATASET_HANDLERS = {
@@ -74,8 +74,7 @@ class CoreHandler(BaseHandler):
         identify_status = self.layer_plugin.identify(self.filepath)
 
         if identify_status:
-            self.layer_plugin.identify_datetime = datetime.now().isoformat()
-
+            self.layer_plugin.identify_datetime = get_today_and_now()
             LOGGER.debug('Registering file')
             self.layer_plugin.register()
 

--- a/geomet_data_registry/layer/base.py
+++ b/geomet_data_registry/layer/base.py
@@ -22,6 +22,7 @@ import logging
 
 from geomet_data_registry.env import STORE_PROVIDER_DEF, TILEINDEX_PROVIDER_DEF
 from geomet_data_registry.plugin import load_plugin
+from geomet_data_registry.util import get_today_and_now
 
 LOGGER = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ class BaseLayer(object):
         self.model_run_list = []
 
         self.file_creation_datetime = None
-        self.receive_datetime = datetime.now()
+        self.receive_datetime = get_today_and_now()
         self.identify_datetime = None
         self.register_datetime = None
         self.filepath = None

--- a/geomet_data_registry/layer/cansips.py
+++ b/geomet_data_registry/layer/cansips.py
@@ -57,7 +57,7 @@ class CansipsLayer(BaseLayer):
 
         self.filepath = filepath
         self.file_creation_datetime = datetime.fromtimestamp(
-                os.path.getmtime(filepath))
+            os.path.getmtime(filepath)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         self.model = 'cansips'
 
         LOGGER.debug('Loading model information from store')
@@ -138,8 +138,8 @@ class CansipsLayer(BaseLayer):
                 'layer_name': layer_name,
                 'filepath': vrt,
                 'identifier': identifier,
-                'reference_datetime': reference_datetime,
-                'forecast_hour_datetime': forecast_hour_datetime,
+                'reference_datetime': reference_datetime.strftime(time_format),
+                'forecast_hour_datetime': forecast_hour_datetime.strftime(time_format),
                 'member': member,
                 'model': self.model,
                 'elevation': elevation,

--- a/geomet_data_registry/layer/model_gem_global.py
+++ b/geomet_data_registry/layer/model_gem_global.py
@@ -56,7 +56,7 @@ class ModelGemGlobalLayer(BaseLayer):
 
         self.filepath = filepath
         self.file_creation_datetime = datetime.fromtimestamp(
-                os.path.getmtime(filepath))
+            os.path.getmtime(filepath)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         self.model = 'model_gem_global'
 
         LOGGER.debug('Loading model information from store')
@@ -116,8 +116,8 @@ class ModelGemGlobalLayer(BaseLayer):
                 'layer_name': layer_name,
                 'filepath': filepath,
                 'identifier': identifier,
-                'reference_datetime': reference_datetime,
-                'forecast_hour_datetime': forecast_hour_datetime,
+                'reference_datetime': reference_datetime.strftime('%Y-%m-%dT%H:%M:%SZ'),
+                'forecast_hour_datetime': forecast_hour_datetime.strftime('%Y-%m-%dT%H:%M:%SZ'),
                 'member': member,
                 'model': self.model,
                 'elevation': elevation,

--- a/geomet_data_registry/layer/radar_1km.py
+++ b/geomet_data_registry/layer/radar_1km.py
@@ -54,8 +54,11 @@ class Radar1kmLayer(BaseLayer):
         :returns: `list` of file properties
         """
 
+        self.filepath = filepath
+        self.file_creation_datetime = datetime.fromtimestamp(
+            os.path.getmtime(filepath)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         self.model = 'radar'
-        self.filepath = filepath    
+
     
         LOGGER.debug('Loading model information from store')
         file_dict = json.loads(self.store.get_key(self.model))
@@ -95,7 +98,7 @@ class Radar1kmLayer(BaseLayer):
             'filepath': filepath,
             'identifier': identifier,
             'reference_datetime': None,
-            'forecast_hour_datetime': date_,
+            'forecast_hour_datetime': date_.strftime('%Y-%m-%dT%H:%M:%SZ'),
             'member': member,
             'model': self.model,
             'elevation': elevation,

--- a/geomet_data_registry/layer/reps.py
+++ b/geomet_data_registry/layer/reps.py
@@ -59,7 +59,7 @@ class RepsLayer(BaseLayer):
 
         self.filepath = filepath
         self.file_creation_datetime = datetime.fromtimestamp(
-                os.path.getmtime(filepath))
+            os.path.getmtime(filepath)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         self.model = 'reps'
 
         LOGGER.debug('Loading model information from store')
@@ -144,8 +144,8 @@ class RepsLayer(BaseLayer):
                     'layer_name': layer_name,
                     'filepath': vrt,
                     'identifier': identifier,
-                    'reference_datetime': reference_datetime,
-                    'forecast_hour_datetime': forecast_hour_datetime,
+                    'reference_datetime': reference_datetime.strftime(time_format),
+                    'forecast_hour_datetime': forecast_hour_datetime.strftime(time_format),
                     'member': member,
                     'model': self.model,
                     'elevation': elevation,

--- a/geomet_data_registry/tileindex/elasticsearch_.py
+++ b/geomet_data_registry/tileindex/elasticsearch_.py
@@ -67,24 +67,31 @@ INDEX_SETTINGS = {
                     },
                     'forecast_hour_datetime': {
                         'type': 'date',
+                        'format': 'date_time_no_millis'
                     },
                     'reference_datetime': {
                         'type': 'date',
+                        'format': 'date_time_no_millis'
                     },
                     'file_creation_datetime': {
                         'type': 'date',
+                        'format': 'date_time'
                     },
                     'receive_datetime': {
                         'type': 'date',
+                        'format': 'date_time'
                     },
                     'identify_datetime': {
                         'type': 'date',
+                        'format': 'date_time'
                     },
                     'register_datetime': {
                         'type': 'date',
+                        'format': 'date_time'
                     },
                     'expiry_datetime': {
                         'type': 'date',
+                        'format': 'date_time'
                     },
                     'elevation': {
                         'type': 'text',
@@ -342,7 +349,7 @@ class ElasticsearchTileIndex(BaseTileIndex):
         for key, value in update_dict.items():
             es_query_body['script'] = {
                 'source': 'ctx._source.properties.{} = "{}"'.format(
-                    key, value.isoformat())
+                    key, value)
             }
 
         LOGGER.debug('ES query body: {}'.format(es_query_body))

--- a/geomet_data_registry/util.py
+++ b/geomet_data_registry/util.py
@@ -17,7 +17,7 @@
 #
 ###############################################################################
 
-from datetime import datetime, date, time
+from datetime import datetime, date, time, timezone
 import json
 import logging
 
@@ -53,3 +53,14 @@ def json_serial(obj):
     msg = '{} type {} not serializable'.format(obj, type(obj))
     LOGGER.error(msg)
     raise TypeError(msg)
+
+
+def get_today_and_now():
+    """
+    helper function to return a string
+    of the current UTC datetime with the Z designator
+    (ex. `2019-09-30T14:49:28.213142Z`)
+
+    :returns: Current UTC datetime as `str`
+    """
+    return datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')


### PR DESCRIPTION
Fixes #49.

Changes to format the `file_creation_datetime`, `reference_datetime` and `forecast_hour_datetime` properties in the various Layer objects (i.e. RepsLayer, ModelGemGlobalLayer)  in UTC ISO 8601 datetime string with the 'Z' designator.

This fix also applies to all the the the various "management" datetime objects such as `received_datetime` and `identify_datetime`.

Using these formats also allows to more strictly define the expected datetime format for each property in the ES mapping for the geomet-data-registry index.