### PR TITLE
added time keyword for radar in store

### DIFF
--- a/geomet_data_registry/handler/__init__.py
+++ b/geomet_data_registry/handler/__init__.py
@@ -63,7 +63,7 @@ def add_data(ctx, file_, directory, verify=False):
         files_to_process = [file_]
     elif directory is not None:
         for root, dirs, files in os.walk(directory):
-            for f in files:
+            for f in sorted(files):
                 files_to_process.append(os.path.join(root, f))
 
     for file_to_process in files_to_process:

--- a/geomet_data_registry/handler/core.py
+++ b/geomet_data_registry/handler/core.py
@@ -17,7 +17,6 @@
 #
 ###############################################################################
 
-from datetime import datetime
 import logging
 
 from geomet_data_registry.plugin import load_plugin
@@ -77,7 +76,8 @@ class CoreHandler(BaseHandler):
             self.layer_plugin.identify_datetime = get_today_and_now()
             LOGGER.debug('Registering file')
             self.layer_plugin.register()
-
+            if self.layer_plugin.new_key_store is True:
+                self.layer_plugin.add_time_key()
         return True
 
     def __repr__(self):

--- a/geomet_data_registry/layer/base.py
+++ b/geomet_data_registry/layer/base.py
@@ -50,6 +50,9 @@ class BaseLayer(object):
         self.model = None
         self.model_run = None
         self.wx_variable = None
+        self.layer_name = None
+        self.date_ = None
+        self.file_dict = None
 
         self.name = provider_def['name']
         self.store = load_plugin('store', STORE_PROVIDER_DEF)
@@ -160,6 +163,7 @@ class BaseLayer(object):
                     layer_count_key_reset = '{}_{}_count'.format(
                         item_dict['properties']['layer'], mr)
                     self.store.set_key(layer_count_key_reset, 0)
+                    # self.new_key_store = True
             elif int(new_layer_file_count) == 1:
                 for mr in self.model_run_list:
                     layer_count_key_reset = '{}_{}_count'.format(
@@ -173,6 +177,18 @@ class BaseLayer(object):
                                                    item['expected_count'],
                                                    item['layer_name']))
                         self.store.set_key(layer_count_key_reset, 0)
+        else:
+            self.new_key_store = True
+
+    def add_time_key(self):
+        """
+        Add time keys when applicable:
+            - model run default time
+            - model run extent
+            - forecast hour extent
+        and for observation:
+            - latest time step
+        """
 
     def __repr__(self):
         return '<BaseLayer> {}'.format(self.name)

--- a/geomet_data_registry/util.py
+++ b/geomet_data_registry/util.py
@@ -23,6 +23,7 @@ import logging
 
 LOGGER = logging.getLogger(__name__)
 
+DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
 def json_pretty_print(data):
     """


### PR DESCRIPTION
added time keyword for radar in store

For radar we have default time and time extent in redis like:

```
127.0.0.1:6379> GET RADAR_1KM_RSNO_default_time
"2019-11-12T15:20:00Z"
127.0.0.1:6379> GET RADAR_1KM_RSNO_time_extent
"2019-11-12T12:20:00Z/2019-11-12T15:20:00Z/PT10M"
```
These can then be used in a mapfile directly and used for logging errors like missing timestep