### PR TITLE
add time keys for NWP models

### DIFF
--- a/geomet_data_registry/layer/cansips.py
+++ b/geomet_data_registry/layer/cansips.py
@@ -25,7 +25,7 @@ import os
 from parse import parse
 import re
 
-from geomet_data_registry.layer.base import BaseLayer, LayerError
+from geomet_data_registry.layer.base import BaseLayer
 
 LOGGER = logging.getLogger(__name__)
 
@@ -139,7 +139,7 @@ class CansipsLayer(BaseLayer):
                 'filepath': vrt,
                 'identifier': identifier,
                 'reference_datetime': reference_datetime.strftime(time_format),
-                'forecast_hour_datetime': forecast_hour_datetime.strftime(time_format),
+                'forecast_hour_datetime': forecast_hour_datetime.strftime(time_format), # noqa
                 'member': member,
                 'model': self.model,
                 'elevation': elevation,
@@ -149,6 +149,19 @@ class CansipsLayer(BaseLayer):
             self.items.append(feature_dict)
 
         return True
+
+    def add_time_key(self):
+        """
+        Add time keys when applicable:
+            - model run default time
+            - model run extent
+            - forecast hour extent
+        and for observation:
+            - latest time step
+        """
+
+        # TODO add function to create time keys
+        pass
 
     def __repr__(self):
         return '<ModelCanSIPSLayer> {}'.format(self.name)

--- a/geomet_data_registry/layer/radar_1km.py
+++ b/geomet_data_registry/layer/radar_1km.py
@@ -84,18 +84,18 @@ class Radar1kmLayer(BaseLayer):
         time_format = '%Y%m%d%H%M'
         self.date_ = datetime.strptime(file_pattern_info['time_'], time_format)
 
-        self.layer_name = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layer']  # noqa
+        layer_name = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layer']  # noqa
 
         member = self.file_dict[self.model]['variable'][self.wx_variable]['member']  # noqa
         elevation = self.file_dict[self.model]['variable'][self.wx_variable]['elevation']  # noqa
         str_fh = re.sub('[^0-9]',
                         '',
                         self.date_.strftime(DATE_FORMAT))
-        identifier = '{}-{}'.format(self.layer_name, str_fh)
+        identifier = '{}-{}'.format(layer_name, str_fh)
         date_format = DATE_FORMAT
 
         feature_dict = {
-            'layer_name': self.layer_name,
+            'layer_name': layer_name,
             'filepath': filepath,
             'identifier': identifier,
             'reference_datetime': None,
@@ -119,10 +119,11 @@ class Radar1kmLayer(BaseLayer):
             - latest time step
         """
 
-        key_name = '{}_default_time'.format(self.layer_name)
+        layer_name = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layer'] # noqa
+        key_name = '{}_default_time'.format(layer_name)
         last_key = self.store.get_key(key_name)
         key_value = self.date_.strftime(DATE_FORMAT)
-        extent_key = '{}_time_extent'.format(self.layer_name)
+        extent_key = '{}_time_extent'.format(layer_name)
         start, end, interval = self.file_dict[self.model]['variable'][self.wx_variable]['forecast_hours'].split('/') # noqa
         start_time = self.date_ + timedelta(minutes=int(start))
         start_time = start_time.strftime(DATE_FORMAT)
@@ -142,4 +143,4 @@ class Radar1kmLayer(BaseLayer):
             self.store.set_key(extent_key, extent_value)
 
     def __repr__(self):
-        return '<ModelGemGlobalLayer> {}'.format(self.name)
+        return '<Radar1KM> {}'.format(self.name)

--- a/geomet_data_registry/layer/reps.py
+++ b/geomet_data_registry/layer/reps.py
@@ -25,7 +25,7 @@ import os
 from parse import parse
 import re
 
-from geomet_data_registry.layer.base import BaseLayer, LayerError
+from geomet_data_registry.layer.base import BaseLayer
 
 LOGGER = logging.getLogger(__name__)
 
@@ -144,8 +144,8 @@ class RepsLayer(BaseLayer):
                     'layer_name': layer_name,
                     'filepath': vrt,
                     'identifier': identifier,
-                    'reference_datetime': reference_datetime.strftime(time_format),
-                    'forecast_hour_datetime': forecast_hour_datetime.strftime(time_format),
+                    'reference_datetime': reference_datetime.strftime(time_format), # noqa
+                    'forecast_hour_datetime': forecast_hour_datetime.strftime(time_format), # noqa
                     'member': member,
                     'model': self.model,
                     'elevation': elevation,
@@ -155,6 +155,19 @@ class RepsLayer(BaseLayer):
                 self.items.append(feature_dict)
 
         return True
+
+    def add_time_key(self):
+        """
+        Add time keys when applicable:
+            - model run default time
+            - model run extent
+            - forecast hour extent
+        and for observation:
+            - latest time step
+        """
+
+        # TODO add function to create time keys
+        pass
 
     def __repr__(self):
         return '<ModelREPSLayer> {}'.format(self.name)

--- a/geomet_data_registry/util.py
+++ b/geomet_data_registry/util.py
@@ -25,6 +25,7 @@ LOGGER = logging.getLogger(__name__)
 
 DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
+
 def json_pretty_print(data):
     """
     Pretty print a JSON serialization


### PR DESCRIPTION
add time keys for NWP models

And yes I forgot but we need the `self.new_key_store = False` because I'm using that key in the handler script to trigger the writting of the time keywords in Redis whenever a model run is complete, or when a new radar file is added. This is done in the count function of the layer/base.py script.