### PR TITLE
refactor file_path_pattern key to more appropriately titled  filename…

### DIFF
--- a/geomet_data_registry/layer/cansips.py
+++ b/geomet_data_registry/layer/cansips.py
@@ -63,7 +63,7 @@ class CansipsLayer(BaseLayer):
         LOGGER.debug('Loading model information from store')
         file_dict = json.loads(self.store.get_key(self.model))
 
-        filename_pattern = file_dict[self.model]['file_path_pattern']
+        filename_pattern = file_dict[self.model]['filename_pattern']
 
         tmp = parse(filename_pattern, os.path.basename(filepath))
 

--- a/geomet_data_registry/layer/model_gem_global.py
+++ b/geomet_data_registry/layer/model_gem_global.py
@@ -63,7 +63,7 @@ class ModelGemGlobalLayer(BaseLayer):
         LOGGER.debug('Loading model information from store')
         self.file_dict = json.loads(self.store.get_key(self.model))
 
-        filename_pattern = self.file_dict[self.model]['file_path_pattern']
+        filename_pattern = self.file_dict[self.model]['filename_pattern']
 
         tmp = parse(filename_pattern, os.path.basename(filepath))
 

--- a/geomet_data_registry/layer/radar_1km.py
+++ b/geomet_data_registry/layer/radar_1km.py
@@ -63,7 +63,7 @@ class Radar1kmLayer(BaseLayer):
         LOGGER.debug('Loading model information from store')
         self.file_dict = json.loads(self.store.get_key(self.model))
 
-        filename_pattern = self.file_dict[self.model]['file_path_pattern']
+        filename_pattern = self.file_dict[self.model]['filename_pattern']
 
         tmp = parse(filename_pattern, os.path.basename(filepath))
 


### PR DESCRIPTION
Changed the `file_path_pattern` key to `filename_pattern` to reflect changes made to config files in msc-geomet-data-registry. Cosmetic, but makes it more clear that it is only getting the filename pattern and not the pattern for the entire filepath.

CC @RousseauLambertLP 