### PR TITLE
initial hrdps layer handler and fixes for gdps handler

### DIFF
--- a/geomet_data_registry/handler/core.py
+++ b/geomet_data_registry/handler/core.py
@@ -26,6 +26,7 @@ LOGGER = logging.getLogger(__name__)
 
 DATASET_HANDLERS = {
     'CMC_glb': 'ModelGemGlobal',
+    'CMC_hrdps_continental': 'ModelHrdpsContinental',
     'RADAR_COMPOSITE_1KM': 'Radar1km',
     'cansips': 'CanSIPS',
     'reps': 'REPS'

--- a/geomet_data_registry/layer/model_hrdps_continental.py
+++ b/geomet_data_registry/layer/model_hrdps_continental.py
@@ -1,6 +1,6 @@
 ###############################################################################
 #
-# Copyright (C) 2019 Tom Kralidis
+# Copyright (C) 2019 Etienne Pelletier
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -30,8 +30,8 @@ from geomet_data_registry.util import DATE_FORMAT
 LOGGER = logging.getLogger(__name__)
 
 
-class ModelGemGlobalLayer(BaseLayer):
-    """GDPS layer"""
+class ModelHrdpsContinentalLayer(BaseLayer):
+    """HRDPS Continental layer"""
 
     def __init__(self, provider_def):
         """
@@ -42,7 +42,7 @@ class ModelGemGlobalLayer(BaseLayer):
         :returns: `geomet_data_registry.layer.model_gem_global.ModelGemGlobalLayer`  # noqa
         """
 
-        provider_def = {'name': 'model_gem_global'}
+        provider_def = {'name': 'model_hrdps_continental'}
 
         BaseLayer.__init__(self, provider_def)
 
@@ -57,7 +57,7 @@ class ModelGemGlobalLayer(BaseLayer):
 
         super().identify(filepath)
 
-        self.model = 'model_gem_global'
+        self.model = 'model_hrdps_continental'
 
         LOGGER.debug('Loading model information from store')
         self.file_dict = json.loads(self.store.get_key(self.model))
@@ -65,7 +65,6 @@ class ModelGemGlobalLayer(BaseLayer):
         filename_pattern = self.file_dict[self.model]['filename_pattern']
 
         tmp = parse(filename_pattern, os.path.basename(filepath))
-
         file_pattern_info = {
             'wx_variable': tmp.named['wx_variable'],
             'time_': tmp.named['YYYYMMDD_model_run'],
@@ -174,4 +173,4 @@ class ModelGemGlobalLayer(BaseLayer):
             self.store.set_key(model_run_extent_key, model_run_extent_value)
 
     def __repr__(self):
-        return '<ModelGemGlobalLayer> {}'.format(self.name)
+        return '<ModelHrdpsContinentalLayer> {}'.format(self.name)

--- a/geomet_data_registry/plugin.py
+++ b/geomet_data_registry/plugin.py
@@ -31,6 +31,7 @@ PLUGINS = {
     },
     'layer': {
         'ModelGemGlobal': 'geomet_data_registry.layer.model_gem_global.ModelGemGlobalLayer',  # noqa
+        'ModelHrdpsContinental': 'geomet_data_registry.layer.model_hrdps_continental.ModelHrdpsContinentalLayer',  # noqa
         'Radar1km': 'geomet_data_registry.layer.radar_1km.Radar1kmLayer',  # noqa
         'CanSIPS': 'geomet_data_registry.layer.cansips.CansipsLayer',  # noqa
         'REPS': 'geomet_data_registry.layer.reps.RepsLayer'  # noqa


### PR DESCRIPTION
Initial HRDPS Continental layer handler. Tested and verified using the CLI tool with data retrieved from the DataMart via wget.

Also, if a file is passed to the GDPS or HRDPS handler and its forecast hour is not included in the variable's `forecast_hour` key in the respective yaml configuration, the identify method now returns False and will not try to register the layer into geomet-data-registry.

Minor PEP8 fixes also included.

