### PR TITLE
set redis to decode responses to strings

### DIFF
--- a/geomet_data_registry/layer/radar_1km.py
+++ b/geomet_data_registry/layer/radar_1km.py
@@ -133,7 +133,6 @@ class Radar1kmLayer(BaseLayer):
             self.store.set_key(extent_key, extent_value)
         else:
             LOGGER.debug('Adding time keys in the store')
-            last_key = last_key.decode('utf-8')
             old_time = datetime.strptime(last_key, DATE_FORMAT)
             if old_time + timedelta(minutes=10) != self.date_:
                 LOGGER.error('Missing radar between {}/{}'.format(old_time,

--- a/geomet_data_registry/store/redis_.py
+++ b/geomet_data_registry/store/redis_.py
@@ -42,7 +42,7 @@ class RedisStore(BaseStore):
         BaseStore.__init__(self, provider_def)
 
         try:
-            self.redis = redis.Redis.from_url(self.url)
+            self.redis = redis.Redis.from_url(self.url, charset='utf-8', decode_responses=True)
         except redis.exceptions.ConnectionError as err:
             msg = 'Cannot connect to Redis {}: {}'.format(self.url, err)
             LOGGER.exception(msg)


### PR DESCRIPTION
This MR adds the `decode_responses=True` keyword argument to the Redis store connection, enabling all responses from Redis to be returned as strings instead of bytes.

I have also removed any `.decode()` calls for any instance where we were decoding bytes when getting keys from the Redis store.

