### PR TITLE
fixed sorting when adding data directory via CLI

### DIFF
--- a/geomet_data_registry/handler/__init__.py
+++ b/geomet_data_registry/handler/__init__.py
@@ -63,8 +63,9 @@ def add_data(ctx, file_, directory, verify=False):
         files_to_process = [file_]
     elif directory is not None:
         for root, dirs, files in os.walk(directory):
-            for f in sorted(files):
+            for f in files:
                 files_to_process.append(os.path.join(root, f))
+        files_to_process.sort(key=os.path.getmtime)
 
     for file_to_process in files_to_process:
         handler = CoreHandler(file_to_process)


### PR DESCRIPTION
This PR fixes an issue where data was not sorted properly when using the CLI `geomet-data-registry data add -d` functionality resulting in older model runs overwriting the `default_model_run` value of the newest model run available in the passed directory.

The approach taken now is to create a complete list of files prior to doing any sorting. Once the list of files is final,  the complete list is sorted by the `mtime` of the file, which is the time the file was initially created.


