### PR TITLE
initial configuration for GEPS

### DIFF
--- a/conf/geps.yml
+++ b/conf/geps.yml
@@ -1,0 +1,1215 @@
+geps:
+    model: GEPS
+    model_run_retention_hours: 72
+    model_run_interval_hours: 12
+    product:
+        filename_pattern: CMC_geps-prob_{wx_variable}_latlon0p5x0p5_{YYYYMMDD_model_run}_P{forecast_hour}_all-products.grib2
+        variable:
+            HEATX_TGL_2m:
+                bands:
+                    1:
+                        product: ERC10
+                    2:
+                        product: ERC25
+                    3:
+                        product: ERC50
+                    4:
+                        product: ERC75
+                    5:
+                        product: ERC90
+                    6:
+                        product: ERSSTD
+                    7:
+                        product: ERMEAN
+                    8:
+                        product: ERC0
+                    9:
+                        product: ERC100
+                elevation: 2m
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 128
+                    12Z:
+                        files_expected: 128
+                geomet_layers:
+                    GEPS.DIAG.3_HMX.{}:
+                        forecast_hours: 003/384/PT3H
+            TCDC_SFC_0:
+                bands:
+                    1:
+                        product: ERC10
+                    2:
+                        product: ERC25
+                    3:
+                        product: ERC50
+                    4:
+                        product: ERC75
+                    5:
+                        product: ERC90
+                    6:
+                        product: ERC0
+                    7:
+                        product: ERC100
+                elevation: surface
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 128
+                    12Z:
+                        files_expected: 128
+                geomet_layers:
+                    GEPS.DIAG.3_NT.{}:
+                        forecast_hours: 003/384/PT3H
+            TEMP_TGL_2:
+                bands:
+                    1:
+                        product: ERC10
+                    2:
+                        product: ERC25
+                    3:
+                        product: ERC50
+                    4:
+                        product: ERC75
+                    5:
+                        product: ERC90
+                    6:
+                        product: ERSSTD
+                    7:
+                        product: ERMEAN
+                    8:
+                        product: ERC0
+                    9:
+                        product: ERC100
+                elevation: 2m
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 128
+                    12Z:
+                        files_expected: 128
+                geomet_layers:
+                    GEPS.DIAG.3_TT.{}:
+                        forecast_hours: 003/384/PT3H
+            WCF_TGL_2m:
+                bands:
+                    1:
+                        product: ERC10
+                    2:
+                        product: ERC25
+                    3:
+                        product: ERC50
+                    4:
+                        product: ERC75
+                    5:
+                        product: ERC90
+                    6:
+                        product: ERSSTD
+                    7:
+                        product: ERMEAN
+                    8:
+                        product: ERC0
+                    9:
+                        product: ERC100
+                elevation: 2m
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 128
+                    12Z:
+                        files_expected: 128
+                geomet_layers:
+                    GEPS.DIAG.3_WCF.{}:
+                        forecast_hours: 003/384/PT3H
+            WIND_TGL_10m:
+                bands:
+                    1:
+                        product: ERC10
+                    2:
+                        product: ERC25
+                    3:
+                        product: ERC50
+                    4:
+                        product: ERC75
+                    5:
+                        product: ERC90
+                    6:
+                        product: ERSSTD
+                    7:
+                        product: ERMEAN
+                    8:
+                        product: ERC0
+                    9:
+                        product: ERC100
+                elevation: 10m
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 128
+                    12Z:
+                        files_expected: 128
+                geomet_layers:
+                    GEPS.DIAG.3_WSPD.{}:
+                        forecast_hours: 003/384/PT3H
+            FPRATE-Accum-12h_SFC_0:
+                bands:
+                    1:
+                        product: ERGE1
+                    2:
+                        product: ERGE2.5
+                    3:
+                        product: ERGE5
+                    4:
+                        product: ERGE10
+                    5:
+                        product: ERGE15
+                    6:
+                        product: ERGE20
+                    7:
+                        product: ERGE25
+                    8:
+                        product: ERGE30
+                    9:
+                        product: ERGE40
+                    10:
+                        product: ERGE50
+                    11:
+                        product: ERC10
+                    12:
+                        product: ERC25
+                    13:
+                        product: ERC50
+                    14:
+                        product: ERC75
+                    15:
+                        product: ERC90
+                    16:
+                        product: ERSSTD
+                    17:
+                        product: ERMEAN
+                    18:
+                        product: ERC0
+                    19:
+                        product: ERC100
+                elevation: surface
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 32
+                    12Z:
+                        files_expected: 32
+                geomet_layers:
+                    GEPS.DIAG.12_FRMM.{}:
+                        forecast_hours: 012/384/PT12H
+            IPRATE-Accum-12h_SFC_0:
+                bands:
+                    1:
+                        product: ERGE1
+                    2:
+                        product: ERGE2.5
+                    3:
+                        product: ERGE5
+                    4:
+                        product: ERGE10
+                    5:
+                        product: ERGE15
+                    6:
+                        product: ERGE20
+                    7:
+                        product: ERGE25
+                    8:
+                        product: ERGE30
+                    9:
+                        product: ERGE40
+                    10:
+                        product: ERGE50
+                    11:
+                        product: ERC10
+                    12:
+                        product: ERC25
+                    13:
+                        product: ERC50
+                    14:
+                        product: ERC75
+                    15:
+                        product: ERC90
+                    16:
+                        product: ERSSTD
+                    17:
+                        product: ERMEAN
+                    18:
+                        product: ERC0
+                    19:
+                        product: ERC100
+                elevation: surface
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 32
+                    12Z:
+                        files_expected: 32
+                geomet_layers:
+                    GEPS.DIAG.12_PEMM.{}:
+                        forecast_hours: 012/384/PT12H
+            RPRATE-Accum-12h_SFC_0:
+                bands:
+                    1:
+                        product: ERGE1
+                    2:
+                        product: ERGE2.5
+                    3:
+                        product: ERGE5
+                    4:
+                        product: ERGE10
+                    5:
+                        product: ERGE15
+                    6:
+                        product: ERGE20
+                    7:
+                        product: ERGE25
+                    8:
+                        product: ERGE30
+                    9:
+                        product: ERGE40
+                    10:
+                        product: ERGE50
+                    11:
+                        product: ERGE75
+                    12:
+                        product: ERGE100
+                    13:
+                        product: ERGE150
+                    14:
+                        product: ERC10
+                    15:
+                        product: ERC25
+                    16:
+                        product: ERC50
+                    17:
+                        product: ERC75
+                    18:
+                        product: ERC90
+                    19:
+                        product: ERSSTD
+                    20:
+                        product: ERMEAN
+                    21:
+                        product: ERC0
+                    22:
+                        product: ERC100
+                elevation: surface
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 32
+                    12Z:
+                        files_expected: 32
+                geomet_layers:
+                    GEPS.DIAG.12_RNMM.{}:
+                        forecast_hours: 012/384/PT12H
+            SPRATE-Accum-12h_SFC_0:
+                bands:
+                    1:
+                        product: ERGE1
+                    2:
+                        product: ERGE2.5
+                    3:
+                        product: ERGE5
+                    4:
+                        product: ERGE10
+                    5:
+                        product: ERGE15
+                    6:
+                        product: ERGE20
+                    7:
+                        product: ERGE25
+                    8:
+                        product: ERGE30
+                    9:
+                        product: ERGE40
+                    10:
+                        product: ERGE50
+                    11:
+                        product: ERGE75
+                    12:
+                        product: ERC10
+                    13:
+                        product: ERC25
+                    14:
+                        product: ERC50
+                    15:
+                        product: ERC75
+                    16:
+                        product: ERC90
+                    17:
+                        product: ERSSTD
+                    18:
+                        product: ERMEAN
+                    19:
+                        product: ERC0
+                    20:
+                        product: ERC100
+                elevation: surface
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 32
+                    12Z:
+                        files_expected: 32
+                geomet_layers:
+                    GEPS.DIAG.12_SNMM.{}:
+                        forecast_hours: 012/384/PT12H
+            TPRATE-Accum-12h_SFC_0:
+                bands:
+                    1:
+                        product: ERGE1
+                    2:
+                        product: ERGE2.5
+                    3:
+                        product: ERGE5
+                    4:
+                        product: ERGE10
+                    5:
+                        product: ERGE15
+                    6:
+                        product: ERGE20
+                    7:
+                        product: ERGE25
+                    8:
+                        product: ERGE30
+                    9:
+                        product: ERGE40
+                    10:
+                        product: ERGE50
+                    11:
+                        product: ERGE75
+                    12:
+                        product: ERGE100
+                    13:
+                        product: ERGE150
+                    14:
+                        product: ERC10
+                    15:
+                        product: ERC25
+                    16:
+                        product: ERC50
+                    17:
+                        product: ERC75
+                    18:
+                        product: ERC90
+                    19:
+                        product: ERSSTD
+                    20:
+                        product: ERMEAN
+                    21:
+                        product: ERC0
+                    22:
+                        product: ERC100
+                elevation: surface
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 32
+                    12Z:
+                        files_expected: 32
+                geomet_layers:
+                    GEPS.DIAG.12_PRMM.{}:
+                        forecast_hours: 012/384/PT12H
+            WIND-Max-12h_TGL_10m:
+                bands:
+                    1:
+                        product: ERGE20
+                    2:
+                        product: ERGE30
+                    3:
+                        product: ERGE37
+                    4:
+                        product: ERGE40
+                    5:
+                        product: ERGE50
+                    6:
+                        product: ERGE62
+                    7:
+                        product: ERGE65
+                    8:
+                        product: ERGE75
+                    9:
+                        product: ERGE40
+                    10:
+                        product: ERGE90
+                    11:
+                        product: ERGE100
+                    12:
+                        product: ERGE118
+                    13:
+                        product: ERC10
+                    14:
+                        product: ERC25
+                    15:
+                        product: ERC50
+                    16:
+                        product: ERC75
+                    17:
+                        product: ERC90
+                    18:
+                        product: ERSSTD
+                    19:
+                        product: ERMEAN
+                    20:
+                        product: ERC0
+                    21:
+                        product: ERC100
+                elevation: 10m
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 32
+                    12Z:
+                        files_expected: 32
+                geomet_layers:
+                    GEPS.DIAG.12_UVMX.{}:
+                        forecast_hours: 012/384/PT12H
+            HGT_ISBL_0500:
+                bands:
+                    1:
+                        product: ERMEAN
+                    2:
+                        product: ERSSTD
+                elevation: 500m
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 32
+                    12Z:
+                        files_expected: 32
+                geomet_layers:
+                    GEPS.DIAG.12_GZ.500.{}:
+                        forecast_hours: 012/384/PT12H
+            PRMSL_MSL_0:
+                bands:
+                    1:
+                        product: ERMEAN
+                    2:
+                        product: ERSSTD
+                elevation: surface
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 32
+                    12Z:
+                        files_expected: 32
+                geomet_layers:
+                    GEPS.DIAG.12_PN-SLP.{}:
+                        forecast_hours: 012/384/PT12H
+            FPRATE-Accum-24h_SFC_0:
+                bands:
+                    1:
+                        product: ERGE1
+                    2:
+                        product: ERGE2.5
+                    3:
+                        product: ERGE5
+                    4:
+                        product: ERGE10
+                    5:
+                        product: ERGE15
+                    6:
+                        product: ERGE20
+                    7:
+                        product: ERGE25
+                    8:
+                        product: ERGE30
+                    9:
+                        product: ERGE40
+                    10:
+                        product: ERGE50
+                    11:
+                        product: ERC10
+                    12:
+                        product: ERC25
+                    13:
+                        product: ERC50
+                    14:
+                        product: ERC75
+                    15:
+                        product: ERC90
+                    16:
+                        product: ERSSTD
+                    17:
+                        product: ERMEAN
+                    18:
+                        product: ERC0
+                    19:
+                        product: ERC100
+                elevation: surface
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 31
+                    12Z:
+                        files_expected: 31
+                geomet_layers:
+                    GEPS.DIAG.24_FRMM.{}:
+                        forecast_hours: 024/384/PT12H
+            IPRATE-Accum-24h_SFC_0:
+                bands:
+                    1:
+                        product: ERGE1
+                    2:
+                        product: ERGE2.5
+                    3:
+                        product: ERGE5
+                    4:
+                        product: ERGE10
+                    5:
+                        product: ERGE15
+                    6:
+                        product: ERGE20
+                    7:
+                        product: ERGE25
+                    8:
+                        product: ERGE30
+                    9:
+                        product: ERGE40
+                    10:
+                        product: ERGE50
+                    11:
+                        product: ERC10
+                    12:
+                        product: ERC25
+                    13:
+                        product: ERC50
+                    14:
+                        product: ERC75
+                    15:
+                        product: ERC90
+                    16:
+                        product: ERSSTD
+                    17:
+                        product: ERMEAN
+                    18:
+                        product: ERC0
+                    19:
+                        product: ERC100
+                elevation: surface
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 31
+                    12Z:
+                        files_expected: 31
+                geomet_layers:
+                    GEPS.DIAG.24_PEMM.{}:
+                        forecast_hours: 024/384/PT12H
+            RPRATE-Accum-24h_SFC_0:
+                bands:
+                    1:
+                        product: ERGE1
+                    2:
+                        product: ERGE2.5
+                    3:
+                        product: ERGE5
+                    4:
+                        product: ERGE10
+                    5:
+                        product: ERGE15
+                    6:
+                        product: ERGE20
+                    7:
+                        product: ERGE25
+                    8:
+                        product: ERGE30
+                    9:
+                        product: ERGE40
+                    10:
+                        product: ERGE50
+                    11:
+                        product: ERGE75
+                    12:
+                        product: ERGE100
+                    13:
+                        product: ERGE150
+                    14:
+                        product: ERC10
+                    15:
+                        product: ERC25
+                    16:
+                        product: ERC50
+                    17:
+                        product: ERC75
+                    18:
+                        product: ERC90
+                    19:
+                        product: ERSSTD
+                    20:
+                        product: ERMEAN
+                    21:
+                        product: ERC0
+                    22:
+                        product: ERC100
+                elevation: surface
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 31
+                    12Z:
+                        files_expected: 31
+                geomet_layers:
+                    GEPS.DIAG.24_RNMM.{}:
+                        forecast_hours: 024/384/PT12H
+            SPRATE-Accum-24h_SFC_0:
+                bands:
+                    1:
+                        product: ERGE20
+                    2:
+                        product: ERGE30
+                    3:
+                        product: ERGE37
+                    4:
+                        product: ERGE40
+                    5:
+                        product: ERGE50
+                    6:
+                        product: ERGE62
+                    7:
+                        product: ERGE65
+                    8:
+                        product: ERGE75
+                    9:
+                        product: ERGE40
+                    10:
+                        product: ERGE90
+                    11:
+                        product: ERGE100
+                    12:
+                        product: ERGE118
+                    13:
+                        product: ERC10
+                    14:
+                        product: ERC25
+                    15:
+                        product: ERC50
+                    16:
+                        product: ERC75
+                    17:
+                        product: ERC90
+                    18:
+                        product: ERSSTD
+                    19:
+                        product: ERMEAN
+                    20:
+                        product: ERC0
+                    21:
+                        product: ERC100
+                elevation: surface
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 31
+                    12Z:
+                        files_expected: 31
+                geomet_layers:
+                    GEPS.DIAG.24_SNMM.{}:
+                        forecast_hours: 024/384/PT12H
+            TPRATE-Accum-24h_SFC_0:
+                bands:
+                    1:
+                        product: ERGE1
+                    2:
+                        product: ERGE2.5
+                    3:
+                        product: ERGE5
+                    4:
+                        product: ERGE10
+                    5:
+                        product: ERGE15
+                    6:
+                        product: ERGE20
+                    7:
+                        product: ERGE25
+                    8:
+                        product: ERGE30
+                    9:
+                        product: ERGE40
+                    10:
+                        product: ERGE50
+                    11:
+                        product: ERGE75
+                    12:
+                        product: ERGE100
+                    13:
+                        product: ERGE150
+                    14:
+                        product: ERGE200
+                    15:
+                        product: ERC10
+                    16:
+                        product: ERC25
+                    17:
+                        product: ERC50
+                    18:
+                        product: ERC75
+                    19:
+                        product: ERC90
+                    20:
+                        product: ERSSTD
+                    21:
+                        product: ERMEAN
+                    22:
+                        product: ERC0
+                    23:
+                        product: ERC100
+                elevation: surface
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 31
+                    12Z:
+                        files_expected: 31
+                geomet_layers:
+                    GEPS.DIAG.24_PRMM.{}:
+                        forecast_hours: 024/384/PT12H
+            HEATX-Max-24h_TGL_2m:
+                bands:
+                    1:
+                        product: ERGE25
+                    2:
+                        product: ERGE30
+                    3:
+                        product: ERGE35
+                    4:
+                        product: ERGE38
+                    5:
+                        product: ERGE40
+                    6:
+                        product: ERGE42
+                    7:
+                        product: ERC10
+                    8:
+                        product: ERC25
+                    9:
+                        product: ERC50
+                    10:
+                        product: ERC75
+                    11:
+                        product: ERC90
+                    12:
+                        product: ERSSTD
+                    13:
+                        product: ERMEAN
+                    14:
+                        product: ERC0
+                    15:
+                        product: ERC100
+                elevation: 2m
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 16
+                    12Z:
+                        files_expected: 16
+                geomet_layers:
+                    GEPS.DIAG.24_HMXX.{}:
+                        forecast_hours: 024/384/PT24H
+            TEMP-Min-24h_TGL_2m:
+                bands:
+                    1:
+                        product: ERLE-40
+                    2:
+                        product: ERLE-35
+                    3:
+                        product: ERLE-30
+                    4:
+                        product: ERLE-25
+                    5:
+                        product: ERLE-20
+                    6:
+                        product: ERLE-15
+                    7:
+                        product: ERLE-10
+                    8:
+                        product: ERLE-5
+                    9:
+                        product: ERLE0
+                    10:
+                        product: ERLE5
+                    11:
+                        product: ERLE10
+                    12:
+                        product: ERLE15
+                    13:
+                        product: ERLE20
+                    14:
+                        product: ERLE25
+                    15:
+                        product: ERC10
+                    16:
+                        product: ERC25
+                    17:
+                        product: ERC50
+                    18:
+                        product: ERC75
+                    19:
+                        product: ERC90
+                    20:
+                        product: ERSSTD
+                    21:
+                        product: ERMEAN
+                    22:
+                        product: ERC0
+                    23:
+                        product: ERC100
+                elevation: 2m
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 16
+                    12Z:
+                        files_expected: 16
+                geomet_layers:
+                    GEPS.DIAG.24_T7.{}:
+                        forecast_hours: 024/384/PT24H
+            TEMP-Max-24h_TGL_2m:
+                bands:
+                    1:
+                        product: ERGE-30
+                    2:
+                        product: ERGE-25
+                    3:
+                        product: ERGE-20
+                    4:
+                        product: ERGE-15
+                    5:
+                        product: ERGE-10
+                    6:
+                        product: ERGE-5
+                    7:
+                        product: ERGE0
+                    8:
+                        product: ERGE5
+                    9:
+                        product: ERGE10
+                    10:
+                        product: ERGE15
+                    11:
+                        product: ERGE20
+                    12:
+                        product: ERGE25
+                    13:
+                        product: ERGE30
+                    14:
+                        product: ERGE35
+                    15:
+                        product: ERGE40
+                    16:
+                        product: ERC10
+                    17:
+                        product: ERC25
+                    18:
+                        product: ERC50
+                    19:
+                        product: ERC75
+                    20:
+                        product: ERC90
+                    21:
+                        product: ERSSTD
+                    22:
+                        product: ERMEAN
+                    23:
+                        product: ERC0
+                    24:
+                        product: ERC100
+                elevation: 2m
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 16
+                    12Z:
+                        files_expected: 16
+                geomet_layers:
+                    GEPS.DIAG.24_T8.{}:
+                        forecast_hours: 024/384/PT24H
+            WCF-Min-24h_TGL_2m:
+                bands:
+                    1:
+                        product: ERGE50
+                    2:
+                        product: ERGE45
+                    3:
+                        product: ERGE40
+                    4:
+                        product: ERGE35
+                    5:
+                        product: ERGE30
+                    6:
+                        product: ERGE25
+                    7:
+                        product: ERGE20
+                    8:
+                        product: ERGE15
+                    9:
+                        product: ERGE10
+                    10:
+                        product: ERGE5
+                    11:
+                        product: ERGE0
+                    12:
+                        product: ERC10
+                    13:
+                        product: ERC25
+                    14:
+                        product: ERC50
+                    15:
+                        product: ERC75
+                    16:
+                        product: ERC90
+                    17:
+                        product: ERSSTD
+                    18:
+                        product: ERMEAN
+                    19:
+                        product: ERC0
+                    20:
+                        product: ERC100
+                elevation: 2m
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 16
+                    12Z:
+                        files_expected: 16
+                geomet_layers:
+                    GEPS.DIAG.24_WCFMIN.{}:
+                        forecast_hours: 024/384/PT24H
+            TPRATE-Accum-48h_SFC_0:
+                bands:
+                    1:
+                        product: ERGE1
+                    2:
+                        product: ERGE2.5
+                    3:
+                        product: ERGE5
+                    4:
+                        product: ERGE10
+                    5:
+                        product: ERGE15
+                    6:
+                        product: ERGE20
+                    7:
+                        product: ERGE25
+                    8:
+                        product: ERGE30
+                    9:
+                        product: ERGE40
+                    10:
+                        product: ERGE50
+                    11:
+                        product: ERGE75
+                    12:
+                        product: ERGE100
+                    13:
+                        product: ERGE150
+                    14:
+                        product: ERGE200
+                    15:
+                        product: ERC10
+                    16:
+                        product: ERC25
+                    17:
+                        product: ERC50
+                    18:
+                        product: ERC50
+                    19:
+                        product: ERC90
+                    20:
+                        product: ERSSTD
+                    21:
+                        product: ERMEAN
+                    22:
+                        product: ERC0
+                    23:
+                        product: ERC100
+                elevation: surface
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 15
+                    12Z:
+                        files_expected: 15
+                geomet_layers:
+                    GEPS.DIAG.48_PRMM.{}:
+                        forecast_hours: 048/384/PT24H
+            TPRATE-Accum-72h_SFC_0:
+                bands:
+                    1:
+                        product: ERGE1
+                    2:
+                        product: ERGE2.5
+                    3:
+                        product: ERGE5
+                    4:
+                        product: ERGE10
+                    5:
+                        product: ERGE15
+                    6:
+                        product: ERGE20
+                    7:
+                        product: ERGE25
+                    8:
+                        product: ERGE30
+                    9:
+                        product: ERGE40
+                    10:
+                        product: ERGE50
+                    11:
+                        product: ERGE75
+                    12:
+                        product: ERGE100
+                    13:
+                        product: ERGE150
+                    14:
+                        product: ERGE200
+                    15:
+                        product: ERC10
+                    16:
+                        product: ERC25
+                    17:
+                        product: ERC50
+                    18:
+                        product: ERC50
+                    19:
+                        product: ERC90
+                    20:
+                        product: ERSSTD
+                    21:
+                        product: ERMEAN
+                    22:
+                        product: ERC0
+                    23:
+                        product: ERC100
+                elevation: surface
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 14
+                    12Z:
+                        files_expected: 14
+                geomet_layers:
+                    GEPS.DIAG.72_PRMM.{}:
+                        forecast_hours: 072/384/PT24H
+            TPRATE-Accum-96h_SFC_0:
+                bands:
+                    1:
+                        product: ERGE1
+                    2:
+                        product: ERGE2.5
+                    3:
+                        product: ERGE5
+                    4:
+                        product: ERGE10
+                    5:
+                        product: ERGE15
+                    6:
+                        product: ERGE20
+                    7:
+                        product: ERGE25
+                    8:
+                        product: ERGE30
+                    9:
+                        product: ERGE40
+                    10:
+                        product: ERGE50
+                    11:
+                        product: ERGE75
+                    12:
+                        product: ERGE100
+                    13:
+                        product: ERGE150
+                    14:
+                        product: ERGE200
+                    15:
+                        product: ERC10
+                    16:
+                        product: ERC25
+                    17:
+                        product: ERC50
+                    18:
+                        product: ERC50
+                    19:
+                        product: ERC90
+                    20:
+                        product: ERSSTD
+                    21:
+                        product: ERMEAN
+                    22:
+                        product: ERC0
+                    23:
+                        product: ERC100
+                elevation: surface
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 13
+                    12Z:
+                        files_expected: 13
+                geomet_layers:
+                    GEPS.DIAG.96_PRMM.{}:
+                        forecast_hours: 096/384/PT24H
+            TPRATE-Accum-120h_SFC_0:
+                bands:
+                    1:
+                        product: ERGE1
+                    2:
+                        product: ERGE2.5
+                    3:
+                        product: ERGE5
+                    4:
+                        product: ERGE10
+                    5:
+                        product: ERGE15
+                    6:
+                        product: ERGE20
+                    7:
+                        product: ERGE25
+                    8:
+                        product: ERGE30
+                    9:
+                        product: ERGE40
+                    10:
+                        product: ERGE50
+                    11:
+                        product: ERGE75
+                    12:
+                        product: ERGE100
+                    13:
+                        product: ERGE150
+                    14:
+                        product: ERGE200
+                    15:
+                        product: ERC10
+                    16:
+                        product: ERC25
+                    17:
+                        product: ERC50
+                    18:
+                        product: ERC50
+                    19:
+                        product: ERC90
+                    20:
+                        product: ERSSTD
+                    21:
+                        product: ERMEAN
+                    22:
+                        product: ERC0
+                    23:
+                        product: ERC100
+                elevation: surface
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 12
+                    12Z:
+                        files_expected: 12
+                geomet_layers:
+                    GEPS.DIAG.120_PRMM.{}:
+                        forecast_hours: 120/384/PT24H

--- a/conf/sarracenia/geps.conf
+++ b/conf/sarracenia/geps.conf
@@ -1,0 +1,10 @@
+broker amqps://anonymous:anonymous@dd.weather.gc.ca/
+queue_name q_${BROKER_USER}.${PROGRAM}.${CONFIG}.${HOSTNAME}
+directory /data/geomet/dev/feeds
+instances 6
+subtopic ensemble.geps.grib2.products.#
+mirror True
+report_back False
+accept .*
+on_file /data/geomet/dev/apps/geomet-data-registry-dev/geomet-data-registry/geomet_data_registry/event.py
+chmod_log 0644

--- a/geomet_data_registry/handler/core.py
+++ b/geomet_data_registry/handler/core.py
@@ -31,7 +31,8 @@ DATASET_HANDLERS = {
     'CMC_hrdps_continental': 'ModelHrdpsContinental',
     'RADAR_COMPOSITE_1KM': 'Radar1km',
     'cansips': 'CanSIPS',
-    'reps': 'REPS'
+    'reps': 'REPS',
+    'geps': 'GEPS',
 }
 
 

--- a/geomet_data_registry/layer/geps.py
+++ b/geomet_data_registry/layer/geps.py
@@ -1,0 +1,206 @@
+###############################################################################
+#
+# Copyright (C) 2019 Louis-Philippe Rousseau-Lambert
+# Copyright (C) 2019 Etienne Pelletier
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+from datetime import datetime, timedelta
+import json
+import logging
+import os
+from parse import parse
+import re
+
+from geomet_data_registry.layer.base import BaseLayer
+from geomet_data_registry.util import DATE_FORMAT
+
+LOGGER = logging.getLogger(__name__)
+
+
+class GepsLayer(BaseLayer):
+    """GEPS layer"""
+
+    def __init__(self, provider_def):
+        """
+        Initialize object
+
+        :param provider_def: provider definition dict
+
+        :returns: `geomet_data_registry.layer.geps.GEPSLayer`  # noqa
+        """
+
+        provider_def = {'name': 'geps'}
+        self.type = None
+        self.bands = None
+        self.layer_names = []
+
+        BaseLayer.__init__(self, provider_def)
+
+    def identify(self, filepath):
+        """
+        Identifies a file of the layer
+
+        :param filepath: filepath from AMQP
+
+        :returns: `list` of file properties
+        """
+
+        super().identify(filepath)
+
+        self.model = 'geps'
+
+        LOGGER.debug('Loading model information from store')
+        self.file_dict = json.loads(self.store.get_key(self.model))
+
+        if self.filepath.endswith('allmbrs.grib2'):
+            filename_pattern = self.file_dict[self.model]['member']['filename_pattern']  # noqa
+            self.type = 'member'
+        elif self.filepath.endswith('all-products.grib2'):
+            filename_pattern = self.file_dict[self.model]['product']['filename_pattern']  # noqa
+            self.type = 'product'
+
+        tmp = parse(filename_pattern, os.path.basename(filepath))
+
+        file_pattern_info = {
+            'wx_variable': tmp.named['wx_variable'],
+            'time_': tmp.named['YYYYMMDD_model_run'],
+            'fh': tmp.named['forecast_hour']
+        }
+
+        LOGGER.debug('Defining the different file properties')
+        self.wx_variable = file_pattern_info['wx_variable']
+
+        var_path = self.file_dict[self.model][self.type]['variable']
+        if self.wx_variable not in var_path:
+            msg = 'Variable "{}" not in ' \
+                  'configuration file'.format(self.wx_variable)
+            LOGGER.warning(msg)
+            return False
+
+        runs = self.file_dict[self.model][self.type]['variable'][self.wx_variable]['model_run'] # noqa
+        self.model_run_list = list(runs.keys())
+
+        weather_var = self.file_dict[self.model][self.type]['variable'][self.wx_variable]  # noqa
+
+        time_format = '%Y%m%d%H'
+        self.date_ = datetime.strptime(file_pattern_info['time_'], time_format)
+        reference_datetime = self.date_
+        self.model_run = '{}Z'.format(self.date_.strftime('%H'))
+        forecast_hour_datetime = self.date_ + \
+            timedelta(hours=int(file_pattern_info['fh']))
+
+        if self.type == 'member':
+            self.bands = self.file_dict[self.model]['member']['bands']
+        elif self.type == 'product':
+            self.bands = weather_var['bands']
+
+        for band in self.bands.keys():
+            vrt = '''\
+<VRTDataset rasterXSize="145" rasterYSize="73">
+    <SRS>'+proj=stere +lat_0=90 +lat_ts=60 +lon_0=250 +k=90 +x_0=0 +y_0=0 +a=6371229 +b=6371229 +units=m +no_defs'</SRS>
+    <GeoTransform> -4.4174117578025218e+06,  1.5000000000000000e+04,  0.0000000000000000e+00,  4.5777534875770006e+05,  0.0000000000000000e+00, -1.5000000000000000e+04</GeoTransform>
+    <VRTRasterBand dataType="Float64" band="1">
+        <ComplexSource>
+            <SourceFilename>{}</SourceFilename>
+            <SourceBand>{}</SourceBand>
+        </ComplexSource>
+    </VRTRasterBand>
+</VRTDataset>'''.format(self.filepath, band).replace('\n', '')  # noqa
+
+            elevation = weather_var['elevation']
+            str_mr = re.sub('[^0-9]',
+                            '',
+                            reference_datetime.strftime(DATE_FORMAT))
+            str_fh = re.sub('[^0-9]',
+                            '',
+                            forecast_hour_datetime.strftime(DATE_FORMAT))
+
+            expected_count = self.file_dict[self.model][self.type]['variable'][self.wx_variable]['model_run'][self.model_run]['files_expected']  # noqa
+
+            for layer in weather_var['geomet_layers'].keys():
+                if self.type == 'member':
+                    member = self.bands[band]['member']
+                    layer_name = layer.format(self.bands[band]['member'])
+
+                elif self.type == 'product':
+                    member = None
+                    layer_name = layer.format(self.bands[band]['product'])
+
+                identifier = '{}-{}-{}'.format(layer_name, str_mr, str_fh)
+
+                feature_dict = {
+                    'layer_name': layer_name,
+                    'filepath': vrt,
+                    'identifier': identifier,
+                    'reference_datetime': reference_datetime.strftime(DATE_FORMAT), # noqa
+                    'forecast_hour_datetime': forecast_hour_datetime.strftime(DATE_FORMAT), # noqa
+                    'member': member,
+                    'model': self.model,
+                    'elevation': elevation,
+                    'expected_count': expected_count
+                }
+
+                self.items.append(feature_dict)
+                self.layer_names.append(layer_name)
+
+        return True
+
+    def add_time_key(self):
+        """
+        Add time keys when applicable:
+            - model run default time
+            - model run extent
+            - forecast hour extent
+        and for observation:
+            - latest time step
+        """
+
+        for key in self.layer_names:  # noqa
+
+            time_extent_key = '{}_time_extent'.format(key)
+
+            wx_info = self.file_dict[self.model][self.type]['variable'][self.wx_variable]  # noqa
+
+            for layer in wx_info['geomet_layers']:
+                if key.startswith(layer.format('')):
+                    start, end, interval = wx_info['geomet_layers'][layer]['forecast_hours'].split('/')  # noqa
+                    start_time = self.date_ + timedelta(hours=int(start))
+                    end_time = self.date_ + timedelta(hours=int(end))
+                    start_time = start_time.strftime(DATE_FORMAT)
+                    end_time = end_time.strftime(DATE_FORMAT)
+                    time_extent_value = '{}/{}/{}'.format(start_time,
+                                                          end_time,
+                                                          interval)
+
+            default_model_key = '{}_default_model_run'.format(key)
+
+            model_run_extent_key = '{}_model_run_extent'.format(key)
+            retention_hours = self.file_dict[self.model]['model_run_retention_hours']  # noqa
+            interval_hours = self.file_dict[self.model]['model_run_interval_hours']  # noqa
+            default_model_run = self.date_.strftime(DATE_FORMAT)
+            run_start_time = (self.date_ - timedelta(hours=retention_hours)).strftime(DATE_FORMAT)  # noqa
+            run_interval = 'PT{}H'.format(interval_hours)
+            model_run_extent_value = '{}/{}/{}'.format(run_start_time, default_model_run, run_interval)  # noqa
+
+            LOGGER.debug('Adding time keys in the store')
+
+            self.store.set_key(time_extent_key, time_extent_value)
+            self.store.set_key(default_model_key, default_model_run)
+            self.store.set_key(model_run_extent_key, model_run_extent_value)
+
+    def __repr__(self):
+        return '<ModelGEPSLayer> {}'.format(self.name)

--- a/geomet_data_registry/plugin.py
+++ b/geomet_data_registry/plugin.py
@@ -36,6 +36,7 @@ PLUGINS = {
         'Radar1km': 'geomet_data_registry.layer.radar_1km.Radar1kmLayer',  # noqa
         'CanSIPS': 'geomet_data_registry.layer.cansips.CansipsLayer',  # noqa
         'REPS': 'geomet_data_registry.layer.reps.RepsLayer',  # noqa
+        'GEPS': 'geomet_data_registry.layer.geps.GepsLayer',  # noqa
         'GIOPS': 'geomet_data_registry.layer.model_giops.GiopsLayer'  # noqa
     }
 }


### PR DESCRIPTION
Adds the inital Global Ensemble Prediction System (GEPS) yml configuration, sarracenia config and layer handler.

The YAML only currently includes GEPS products and not the raw data (i.e member data). This will be done at a later date.

Validated with complete model runs pulled from DD.