### PR TITLE
change VRT referencing to new vrt:// method

### DIFF
--- a/geomet_data_registry/layer/geps.py
+++ b/geomet_data_registry/layer/geps.py
@@ -109,17 +109,7 @@ class GepsLayer(BaseLayer):
             self.bands = weather_var['bands']
 
         for band in self.bands.keys():
-            vrt = '''\
-<VRTDataset rasterXSize="145" rasterYSize="73">
-    <SRS>'+proj=stere +lat_0=90 +lat_ts=60 +lon_0=250 +k=90 +x_0=0 +y_0=0 +a=6371229 +b=6371229 +units=m +no_defs'</SRS>
-    <GeoTransform> -4.4174117578025218e+06,  1.5000000000000000e+04,  0.0000000000000000e+00,  4.5777534875770006e+05,  0.0000000000000000e+00, -1.5000000000000000e+04</GeoTransform>
-    <VRTRasterBand dataType="Float64" band="1">
-        <ComplexSource>
-            <SourceFilename>{}</SourceFilename>
-            <SourceBand>{}</SourceBand>
-        </ComplexSource>
-    </VRTRasterBand>
-</VRTDataset>'''.format(self.filepath, band).replace('\n', '')  # noqa
+            vrt = 'vrt://{}?bands={}'.format(self.filepath, band)  # noqa
 
             elevation = weather_var['elevation']
             str_mr = re.sub('[^0-9]',
@@ -146,8 +136,8 @@ class GepsLayer(BaseLayer):
                     'layer_name': layer_name,
                     'filepath': vrt,
                     'identifier': identifier,
-                    'reference_datetime': reference_datetime.strftime(DATE_FORMAT), # noqa
-                    'forecast_hour_datetime': forecast_hour_datetime.strftime(DATE_FORMAT), # noqa
+                    'reference_datetime': reference_datetime.strftime(DATE_FORMAT),  # noqa
+                    'forecast_hour_datetime': forecast_hour_datetime.strftime(DATE_FORMAT),  # noqa
                     'member': member,
                     'model': self.model,
                     'elevation': elevation,


### PR DESCRIPTION
Use the new `vrt://` URI for on-the-fly VRT creation for GEPS layer handler.

Also, minor PEP 8 fixes.