### PR TITLE
improve time key adding logic

### DIFF
--- a/geomet_data_registry/layer/cgsl.py
+++ b/geomet_data_registry/layer/cgsl.py
@@ -161,6 +161,7 @@ class CgslLayer(BaseLayer):
                                                   interval)
 
             default_model_key = '{}_default_model_run'.format(key)
+            stored_default_model_run = self.store.get_key(default_model_key)
 
             model_run_extent_key = '{}_model_run_extent'.format(key)
             retention_hours = self.file_dict[self.model]['model_run_retention_hours']  # noqa
@@ -169,6 +170,11 @@ class CgslLayer(BaseLayer):
             run_start_time = (self.date_ - timedelta(hours=retention_hours)).strftime(DATE_FORMAT)  # noqa
             run_interval = 'PT{}H'.format(interval_hours)
             model_run_extent_value = '{}/{}/{}'.format(run_start_time, default_model_run, run_interval)  # noqa
+
+            if stored_default_model_run and datetime.strptime(stored_default_model_run, DATE_FORMAT) > self.date_:
+                LOGGER.debug("New default model run value ({}) is older than the current value in store: {}. "
+                             "Not updating time keys.".format(default_model_run, stored_default_model_run))
+                continue
 
             LOGGER.debug('Adding time keys in the store')
 

--- a/geomet_data_registry/layer/geps.py
+++ b/geomet_data_registry/layer/geps.py
@@ -177,6 +177,7 @@ class GepsLayer(BaseLayer):
                                                           interval)
 
             default_model_key = '{}_default_model_run'.format(key)
+            stored_default_model_run = self.store.get_key(default_model_key)
 
             model_run_extent_key = '{}_model_run_extent'.format(key)
             retention_hours = self.file_dict[self.model]['model_run_retention_hours']  # noqa
@@ -185,6 +186,11 @@ class GepsLayer(BaseLayer):
             run_start_time = (self.date_ - timedelta(hours=retention_hours)).strftime(DATE_FORMAT)  # noqa
             run_interval = 'PT{}H'.format(interval_hours)
             model_run_extent_value = '{}/{}/{}'.format(run_start_time, default_model_run, run_interval)  # noqa
+
+            if stored_default_model_run and datetime.strptime(stored_default_model_run, DATE_FORMAT) > self.date_:
+                LOGGER.debug("New default model run value ({}) is older than the current value in store: {}. "
+                             "Not updating time keys.".format(default_model_run, stored_default_model_run))
+                continue
 
             LOGGER.debug('Adding time keys in the store')
 

--- a/geomet_data_registry/layer/model_gem_global.py
+++ b/geomet_data_registry/layer/model_gem_global.py
@@ -159,6 +159,7 @@ class ModelGemGlobalLayer(BaseLayer):
                                                   interval)
 
             default_model_key = '{}_default_model_run'.format(key)
+            stored_default_model_run = self.store.get_key(default_model_key)
 
             model_run_extent_key = '{}_model_run_extent'.format(key)
             retention_hours = self.file_dict[self.model]['model_run_retention_hours']  # noqa
@@ -167,6 +168,11 @@ class ModelGemGlobalLayer(BaseLayer):
             run_start_time = (self.date_ - timedelta(hours=retention_hours)).strftime(DATE_FORMAT)  # noqa
             run_interval = 'PT{}H'.format(interval_hours)
             model_run_extent_value = '{}/{}/{}'.format(run_start_time, default_model_run, run_interval)  # noqa
+
+            if stored_default_model_run and datetime.strptime(stored_default_model_run, DATE_FORMAT) > self.date_:
+                LOGGER.debug("New default model run value ({}) is older than the current value in store: {}. "
+                             "Not updating time keys.".format(default_model_run, stored_default_model_run))
+                continue
 
             LOGGER.debug('Adding time keys in the store')
 

--- a/geomet_data_registry/layer/model_gem_regional.py
+++ b/geomet_data_registry/layer/model_gem_regional.py
@@ -159,6 +159,7 @@ class ModelGemRegionalLayer(BaseLayer):
                                                   interval)
 
             default_model_key = '{}_default_model_run'.format(key)
+            stored_default_model_run = self.store.get_key(default_model_key)
 
             model_run_extent_key = '{}_model_run_extent'.format(key)
             retention_hours = self.file_dict[self.model]['model_run_retention_hours']  # noqa
@@ -167,6 +168,11 @@ class ModelGemRegionalLayer(BaseLayer):
             run_start_time = (self.date_ - timedelta(hours=retention_hours)).strftime(DATE_FORMAT)  # noqa
             run_interval = 'PT{}H'.format(interval_hours)
             model_run_extent_value = '{}/{}/{}'.format(run_start_time, default_model_run, run_interval)  # noqa
+
+            if stored_default_model_run and datetime.strptime(stored_default_model_run, DATE_FORMAT) > self.date_:
+                LOGGER.debug("New default model run value ({}) is older than the current value in store: {}. "
+                             "Not updating time keys.".format(default_model_run, stored_default_model_run))
+                continue
 
             LOGGER.debug('Adding time keys in the store')
 

--- a/geomet_data_registry/layer/model_giops.py
+++ b/geomet_data_registry/layer/model_giops.py
@@ -201,6 +201,7 @@ class GiopsLayer(BaseLayer):
                                                           interval)
 
             default_model_key = '{}_default_model_run'.format(key)
+            stored_default_model_run = self.store.get_key(default_model_key)
 
             model_run_extent_key = '{}_model_run_extent'.format(key)
             retention_hours = self.file_dict[self.model_base]['model_run_retention_hours']  # noqa
@@ -209,6 +210,11 @@ class GiopsLayer(BaseLayer):
             run_start_time = (self.date_ - timedelta(hours=retention_hours)).strftime(DATE_FORMAT)  # noqa
             run_interval = 'PT{}H'.format(interval_hours)
             model_run_extent_value = '{}/{}/{}'.format(run_start_time, default_model_run, run_interval)  # noqa
+
+            if stored_default_model_run and datetime.strptime(stored_default_model_run, DATE_FORMAT) > self.date_:
+                LOGGER.debug("New default model run value ({}) is older than the current value in store: {}. "
+                             "Not updating time keys.".format(default_model_run, stored_default_model_run))
+                continue
 
             LOGGER.debug('Adding time keys in the store - Variable: {} - Key: {} - Model run: {}'.format(key, self.wx_variable, default_model_run))
 

--- a/geomet_data_registry/layer/model_hrdps_continental.py
+++ b/geomet_data_registry/layer/model_hrdps_continental.py
@@ -157,6 +157,7 @@ class ModelHrdpsContinentalLayer(BaseLayer):
                                                   interval)
 
             default_model_key = '{}_default_model_run'.format(key)
+            stored_default_model_run = self.store.get_key(default_model_key)
 
             model_run_extent_key = '{}_model_run_extent'.format(key)
             retention_hours = self.file_dict[self.model]['model_run_retention_hours']  # noqa
@@ -165,6 +166,11 @@ class ModelHrdpsContinentalLayer(BaseLayer):
             run_start_time = (self.date_ - timedelta(hours=retention_hours)).strftime(DATE_FORMAT)  # noqa
             run_interval = 'PT{}H'.format(interval_hours)
             model_run_extent_value = '{}/{}/{}'.format(run_start_time, default_model_run, run_interval)  # noqa
+
+            if stored_default_model_run and datetime.strptime(stored_default_model_run, DATE_FORMAT) > self.date_:
+                LOGGER.debug("New default model run value ({}) is older than the current value in store: {}. "
+                             "Not updating time keys.".format(default_model_run, stored_default_model_run))
+                continue
 
             LOGGER.debug('Adding time keys in the store')
 

--- a/geomet_data_registry/layer/reps.py
+++ b/geomet_data_registry/layer/reps.py
@@ -177,6 +177,7 @@ class RepsLayer(BaseLayer):
                                                           interval)
 
             default_model_key = '{}_default_model_run'.format(key)
+            stored_default_model_run = self.store.get_key(default_model_key)
 
             model_run_extent_key = '{}_model_run_extent'.format(key)
             retention_hours = self.file_dict[self.model]['model_run_retention_hours']  # noqa
@@ -185,6 +186,11 @@ class RepsLayer(BaseLayer):
             run_start_time = (self.date_ - timedelta(hours=retention_hours)).strftime(DATE_FORMAT)  # noqa
             run_interval = 'PT{}H'.format(interval_hours)
             model_run_extent_value = '{}/{}/{}'.format(run_start_time, default_model_run, run_interval)  # noqa
+
+            if stored_default_model_run and datetime.strptime(stored_default_model_run, DATE_FORMAT) > self.date_:
+                LOGGER.debug("New default model run value ({}) is older than the current value in store: {}. "
+                             "Not updating time keys.".format(default_model_run, stored_default_model_run))
+                continue
 
             LOGGER.debug('Adding time keys in the store')
 


### PR DESCRIPTION
Small PR to catch instances where, if an older complete model run was added via the CLI, the time keys would be updated and replace those of the most recent model run using the older datetimes.

Technically, this should never happen via AMQP but could happen via the CLI when, for example, we decide to load a model run a previous model run manually in case of a failure with AMQP.