### PR TITLE
Initial GDPS UU layers implementation

### DIFF
--- a/conf/model_gem_global.yml
+++ b/conf/model_gem_global.yml
@@ -1,6 +1,9 @@
 model_gem_global:
     model: GDPS
     filename_pattern: CMC_glb_{wx_variable}_latlon.15x.15_{YYYYMMDD_model_run}_P{forecast_hour}.grib2
+    dimensions:
+        x: 2400
+        y: 1201
     model_run_retention_hours: 48
     model_run_interval_hours: 12
     variable:
@@ -1817,6 +1820,1384 @@ model_gem_global:
             geomet_layers:
                 GDPS.ETA_I0:
                     forecast_hours: 000/240/PT3H
+
+        UGRD_ISBL_1015:
+            members: null
+            elevation: 1015mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_UGRD.1015.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UGRD.1015.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.1015.3h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.1015.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.1015.6h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.1015.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        UGRD_ISBL_1000:
+            members: null
+            elevation: 1000mb
+            model_run:
+                00Z:
+                    files_expected: 81
+                12Z:
+                    files_expected: 81
+            geomet_layers:
+                GDPS.PRES_UGRD.1000:
+                    forecast_hours: 000/240/PT3H
+                GDPS.PRES_UU.1000:
+                    dependencies:
+                        - GDPS.PRES_VGRD.1000
+                    forecast_hours: 000/240/PT3H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        UGRD_ISBL_985:
+            members: null
+            elevation: 985mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_UGRD.985.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UGRD.985.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.985.3h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.985.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.985.6h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.985.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        UGRD_ISBL_970:
+            members: null
+            elevation: 970mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_UGRD.970.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UGRD.970.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.970.3h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.970.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.970.6h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.970.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        UGRD_ISBL_950:
+            members: null
+            elevation: 950mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_UGRD.950.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UGRD.950.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.950.3h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.950.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.950.6h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.950.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        UGRD_ISBL_925:
+            members: null
+            elevation: 925mb
+            model_run:
+                00Z:
+                    files_expected: 81
+                12Z:
+                    files_expected: 81
+            geomet_layers:
+                GDPS.PRES_UGRD.925:
+                    forecast_hours: 000/240/PT3H
+                GDPS.PRES_UU.925:
+                    dependencies:
+                        - GDPS.PRES_VGRD.925
+                    forecast_hours: 000/240/PT3H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        UGRD_ISBL_900:
+            members: null
+            elevation: 900mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_UGRD.900.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UGRD.900.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.900.3h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.900.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.900.6h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.900.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        UGRD_ISBL_875:
+            members: null
+            elevation: 875mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_UGRD.875.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UGRD.875.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.875.3h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.875.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.875.6h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.875.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        UGRD_ISBL_850:
+            members: null
+            elevation: 850mb
+            model_run:
+                00Z:
+                    files_expected: 81
+                12Z:
+                    files_expected: 81
+            geomet_layers:
+                GDPS.PRES_UGRD.850:
+                    forecast_hours: 000/240/PT3H
+                GDPS.PRES_UU.850:
+                    dependencies:
+                        - GDPS.PRES_VGRD.850
+                    forecast_hours: 000/240/PT3H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+                    
+        UGRD_ISBL_800:
+            members: null
+            elevation: 800mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_UGRD.800.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UGRD.800.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.800.3h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.800.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.800.6h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.800.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        UGRD_ISBL_750:
+            members: null
+            elevation: 750mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_UGRD.750.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UGRD.750.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.750.3h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.750.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.750.6h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.750.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        UGRD_ISBL_700:
+            members: null
+            elevation: 700mb
+            model_run:
+                00Z:
+                    files_expected: 81
+                12Z:
+                    files_expected: 81
+            geomet_layers:
+                GDPS.PRES_UGRD.700:
+                    forecast_hours: 000/240/PT3H
+                GDPS.PRES_UU.700:
+                    dependencies:
+                        - GDPS.PRES_VGRD.700
+                    forecast_hours: 000/240/PT3H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        UGRD_ISBL_650:
+            members: null
+            elevation: 650mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_UGRD.650.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UGRD.650.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.650.3h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.650.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.650.6h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.650.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        UGRD_ISBL_600:
+            members: null
+            elevation: 600mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_UGRD.600.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UGRD.600.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.600.3h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.600.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.600.6h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.600.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        UGRD_ISBL_550:
+            members: null
+            elevation: 550mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_UGRD.550.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UGRD.550.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.550.3h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.550.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.550.6h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.550.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        UGRD_ISBL_500:
+            members: null
+            elevation: 500mb
+            model_run:
+                00Z:
+                    files_expected: 81
+                12Z:
+                    files_expected: 81
+            geomet_layers:
+                GDPS.PRES_UGRD.500:
+                    forecast_hours: 000/240/PT3H
+                GDPS.PRES_UU.500:
+                    dependencies:
+                        - GDPS.PRES_VGRD.500
+                    forecast_hours: 000/240/PT3H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        UGRD_ISBL_450:
+            members: null
+            elevation: 450mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_UGRD.450.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UGRD.450.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.450.3h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.450.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.450.6h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.450.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        UGRD_ISBL_400:
+            members: null
+            elevation: 400mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_UGRD.400.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UGRD.400.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.400.3h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.400.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.400.6h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.400.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+        
+        UGRD_ISBL_350:
+            members: null
+            elevation: 350mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_UGRD.350.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UGRD.350.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.350.3h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.350.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.350.6h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.350.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        UGRD_ISBL_300:
+            members: null
+            elevation: 300mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_UGRD.300.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UGRD.300.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.300.3h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.300.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.300.6h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.300.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+        
+        UGRD_ISBL_275:
+            members: null
+            elevation: 275mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_UGRD.275.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UGRD.275.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.275.3h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.275.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.275.6h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.275.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        UGRD_ISBL_250:
+            members: null
+            elevation: 250mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_UGRD.250.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UGRD.250.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.250.3h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.250.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.250.6h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.250.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+        
+        UGRD_ISBL_225:
+            members: null
+            elevation: 225mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_UGRD.225.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UGRD.225.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.225.3h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.225.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.225.6h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.225.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+        
+        UGRD_ISBL_200:
+            members: null
+            elevation: 200mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_UGRD.200.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UGRD.200.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.200.3h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.200.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.200.6h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.200.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+        
+        UGRD_ISBL_175:
+            members: null
+            elevation: 175mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_UGRD.175.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UGRD.175.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.175.3h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.175.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.175.6h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.175.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+        
+        UGRD_ISBL_150:
+            members: null
+            elevation: 150mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_UGRD.150.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UGRD.150.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.150.3h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.150.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.150.6h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.150.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+                    
+        UGRD_ISBL_100:
+            members: null
+            elevation: 100mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_UGRD.100.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UGRD.100.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.100.3h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.100.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.100.6h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.100.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+                    
+        UGRD_ISBL_50:
+            members: null
+            elevation: 50mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_UGRD.50.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UGRD.50.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.50.3h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.50.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.50.6h:
+                    dependencies:
+                        - GDPS.PRES_VGRD.50.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        UGRD_TGL_10:
+            members: null
+            elevation: surface
+            model_run:
+                00Z:
+                    files_expected: 81
+                12Z:
+                    files_expected: 81
+            geomet_layers:
+                GDPS.ETA_UGRD:
+                    forecast_hours: 000/240/PT3H
+                GDPS.ETA_UU:
+                    dependencies:
+                        - GDPS.ETA_VGRD
+                    forecast_hours: 000/240/PT3H
+            bands_order:
+                - UGRD_TGL
+                - VGRD_TGL
+
+        VGRD_ISBL_1015:
+            members: null
+            elevation: 1015mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_VGRD.1015.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_VGRD.1015.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.1015.3h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.1015.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.1015.6h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.1015.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        VGRD_ISBL_1000:
+            members: null
+            elevation: 1000mb
+            model_run:
+                00Z:
+                    files_expected: 81
+                12Z:
+                    files_expected: 81
+            geomet_layers:
+                GDPS.PRES_VGRD.1000:
+                    forecast_hours: 000/240/PT3H
+                GDPS.PRES_UU.1000:
+                    dependencies:
+                        - GDPS.PRES_UGRD.1000
+                    forecast_hours: 000/240/PT3H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+                    
+        VGRD_ISBL_985:
+            members: null
+            elevation: 985mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_VGRD.985.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_VGRD.985.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.985.3h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.985.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.985.6h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.985.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+                    
+        VGRD_ISBL_970:
+            members: null
+            elevation: 970mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_VGRD.970.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_VGRD.970.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.970.3h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.970.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.970.6h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.970.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        VGRD_ISBL_950:
+            members: null
+            elevation: 950mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_VGRD.950.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_VGRD.950.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.950.3h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.950.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.950.6h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.950.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        VGRD_ISBL_925:
+            members: null
+            elevation: 925mb
+            model_run:
+                00Z:
+                    files_expected: 81
+                12Z:
+                    files_expected: 81
+            geomet_layers:
+                GDPS.PRES_VGRD.925:
+                    forecast_hours: 000/240/PT3H
+                GDPS.PRES_UU.925:
+                    dependencies:
+                        - GDPS.PRES_UGRD.925
+                    forecast_hours: 000/240/PT3H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        VGRD_ISBL_900:
+            members: null
+            elevation: 900mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_VGRD.900.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_VGRD.900.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.900.3h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.900.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.900.6h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.900.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        VGRD_ISBL_875:
+            members: null
+            elevation: 875mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_VGRD.875.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_VGRD.875.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.875.3h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.875.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.875.6h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.875.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        VGRD_ISBL_850:
+            members: null
+            elevation: 850mb
+            model_run:
+                00Z:
+                    files_expected: 81
+                12Z:
+                    files_expected: 81
+            geomet_layers:
+                GDPS.PRES_VGRD.850:
+                    forecast_hours: 000/240/PT3H
+                GDPS.PRES_UU.850:
+                    dependencies:
+                        - GDPS.PRES_UGRD.850
+                    forecast_hours: 000/240/PT3H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+                    
+        VGRD_ISBL_800:
+            members: null
+            elevation: 800mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_VGRD.800.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_VGRD.800.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.800.3h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.800.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.800.6h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.800.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        VGRD_ISBL_750:
+            members: null
+            elevation: 750mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_VGRD.750.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_VGRD.750.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.750.3h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.750.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.750.6h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.750.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        VGRD_ISBL_700:
+            members: null
+            elevation: 700mb
+            model_run:
+                00Z:
+                    files_expected: 81
+                12Z:
+                    files_expected: 81
+            geomet_layers:
+                GDPS.PRES_VGRD.700:
+                    forecast_hours: 000/240/PT3H
+                GDPS.PRES_UU.700:
+                    dependencies:
+                        - GDPS.PRES_UGRD.700
+                    forecast_hours: 000/240/PT3H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        VGRD_ISBL_650:
+            members: null
+            elevation: 650mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_VGRD.650.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_VGRD.650.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.650.3h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.650.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.650.6h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.650.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        VGRD_ISBL_600:
+            members: null
+            elevation: 600mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_VGRD.600.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_VGRD.600.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.600.3h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.600.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.600.6h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.600.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+                    
+        VGRD_ISBL_550:
+            members: null
+            elevation: 550mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_VGRD.550.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_VGRD.550.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.550.3h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.550.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.550.6h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.550.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        VGRD_ISBL_500:
+            members: null
+            elevation: 500mb
+            model_run:
+                00Z:
+                    files_expected: 81
+                12Z:
+                    files_expected: 81
+            geomet_layers:
+                GDPS.PRES_VGRD.500:
+                    forecast_hours: 000/240/PT3H
+                GDPS.PRES_UU.500:
+                    dependencies:
+                        - GDPS.PRES_UGRD.500
+                    forecast_hours: 000/240/PT3H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+                    
+        VGRD_ISBL_450:
+            members: null
+            elevation: 450mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_VGRD.450.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_VGRD.450.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.450.3h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.450.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.450.6h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.450.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        VGRD_ISBL_400:
+            members: null
+            elevation: 400mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_VGRD.400.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_VGRD.400.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.400.3h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.400.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.400.6h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.400.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        VGRD_ISBL_350:
+            members: null
+            elevation: 350mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_VGRD.350.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_VGRD.350.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.350.3h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.350.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.350.6h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.350.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+                    
+        VGRD_ISBL_300:
+            members: null
+            elevation: 300mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_VGRD.300.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_VGRD.300.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.300.3h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.300.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.300.6h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.300.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        VGRD_ISBL_275:
+            members: null
+            elevation: 275mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_VGRD.275.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_VGRD.275.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.275.3h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.275.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.275.6h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.275.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        VGRD_ISBL_250:
+            members: null
+            elevation: 250mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_VGRD.250.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_VGRD.250.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.250.3h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.250.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.250.6h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.250.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        VGRD_ISBL_225:
+            members: null
+            elevation: 225mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_VGRD.225.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_VGRD.225.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.225.3h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.225.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.225.6h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.225.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        VGRD_ISBL_200:
+            members: null
+            elevation: 200mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_VGRD.200.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_VGRD.200.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.200.3h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.200.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.200.6h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.200.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        VGRD_ISBL_175:
+            members: null
+            elevation: 175mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_VGRD.175.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_VGRD.175.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.175.3h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.175.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.175.6h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.175.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        VGRD_ISBL_150:
+            members: null
+            elevation: 150mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_VGRD.150.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_VGRD.150.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.150.3h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.150.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.150.6h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.150.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        VGRD_ISBL_100:
+            members: null
+            elevation: 100mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_VGRD.100.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_VGRD.100.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.100.3h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.100.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.100.6h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.100.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        VGRD_ISBL_50:
+            members: null
+            elevation: 50mb
+            model_run:
+                00Z:
+                    files_expected: 69
+                12Z:
+                    files_expected: 69
+            geomet_layers:
+                GDPS.PRES_VGRD.50.3h:
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_VGRD.50.6h:
+                    forecast_hours: 000/240/PT6H
+                GDPS.PRES_UU.50.3h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.50.3h
+                    forecast_hours: 000/168/PT3H
+                GDPS.PRES_UU.50.6h:
+                    dependencies:
+                        - GDPS.PRES_UGRD.50.6h
+                    forecast_hours: 000/240/PT6H
+            bands_order:
+                - UGRD_ISBL
+                - VGRD_ISBL
+
+        VGRD_TGL_10:
+            members: null
+            elevation: surface
+            model_run:
+                00Z:
+                    files_expected: 81
+                12Z:
+                    files_expected: 81
+            geomet_layers:
+                GDPS.ETA_VGRD:
+                    forecast_hours: 000/240/PT3H
+                GDPS.ETA_UU:
+                    dependencies:
+                        - GDPS.ETA_UGRD
+                    forecast_hours: 000/240/PT3H
+            bands_order:
+                - UGRD_TGL
+                - VGRD_TGL
 
         VVEL_ISBL_250:
             members: null

--- a/geomet_data_registry/tileindex/elasticsearch_.py
+++ b/geomet_data_registry/tileindex/elasticsearch_.py
@@ -359,5 +359,16 @@ class ElasticsearchTileIndex(BaseTileIndex):
 
         return 200
 
+    def get(self, identifier):
+        """
+        :param identifier: identifier of document to retrieve
+        :returns: `dict` of single GeoJSON feature
+        """
+        try:
+            result = self.es.get(index=self.name, id=identifier)
+            return result['_source']
+        except exceptions.NotFoundError as err:
+            LOGGER.warning('Could not get document with id: {}'.format(err))
+
     def __repr__(self):
         return '<ElasticsearchTileIndex> {}'.format(self.url)

--- a/geomet_data_registry/util.py
+++ b/geomet_data_registry/util.py
@@ -20,10 +20,91 @@
 from datetime import datetime, date, time, timezone
 import json
 import logging
+import re
+from textwrap import dedent
 
 LOGGER = logging.getLogger(__name__)
 
 DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
+
+
+class VRTDataset:
+    """
+    Object used to create VRTs. The object can be passed a list of ordered
+    variable names to sort the provided file paths on and create a VRT with the
+    bands in the specified list order (ex. UU layers where the U data needs
+    to be the first band and the V data the second band).
+    """
+
+    def __init__(self, filepaths, raster_x_size=None, raster_y_size=None,
+                 bands_order=None):
+        self.vrt_dataset = [
+            '<VRTDataset rasterXSize="{}" rasterYSize="{}" bands="{}">'.format(
+                raster_x_size, raster_y_size, len(filepaths)),
+            '</VRTDataset>'
+        ]
+        self.vrt_raster_band_template = '''\
+        <VRTRasterBand dataType="Byte" band="{}">
+            <ComplexSource>
+                <SourceFilename>{}</SourceFilename>
+                <SourceBand>1</SourceBand>
+                <ScaleOffset>0.0</ScaleOffset>
+                <ScaleRatio>1.0</ScaleRatio>
+            </ComplexSource>
+        </VRTRasterBand>'''
+        self.filepaths = filepaths
+        self.bands_order = bands_order
+
+    def build(self):
+        """
+        Builds a VRT. If self.bands_order is passed during object
+        instantiation,self.filepaths will be sorted according to the
+        provided order and the resulting VRT will create the bands in the
+        specified order.
+        :returns: `str` of VRT.
+        """
+        if self.bands_order:
+            self.filepaths = sorted(self.filepaths,
+                                    key=lambda fp:self.sort_band(fp))
+
+        for index, filepath in enumerate(self.filepaths, start=1):
+            self.vrt_dataset.insert(-1, self.vrt_raster_band_template.format(
+                index, filepath))
+
+        return self.collapse()
+
+    def sort_band(self, filepath):
+        """
+        :param filepath: `str` representation of filepath
+        :returns: `int` of new filepath position in relation to
+        self.bands_order
+        """
+        LOGGER.debug("Checking filepath against provided bands order.")
+        filepath_postion = [idx for idx, value in enumerate(self.bands_order)
+                if value in filepath]
+        if len(filepath_postion) != 1:
+            msg = "Band order could not be determined. Band order values do" \
+                  " not match filepath or filepath matches several band " \
+                  "order values."
+            raise VRTDatasetError(msg)
+
+        return filepath_postion
+
+    def collapse(self):
+        """
+        Collapses VRT to a single-line string
+        :return: `str` representation of VRT as single line with no whitespace
+        formatting
+        """
+        formatted_vrt = ''
+        for item in self.vrt_dataset:
+            formatted_vrt += dedent(re.sub('>\s+<', '><', item))
+
+        return formatted_vrt
+
+
+class VRTDatasetError(Exception):
+    pass
 
 
 def json_pretty_print(data):


### PR DESCRIPTION
This PR contains an implementation for managing GeoMet GDPS layers that require having two or more variables in the registry before creating the tileindex record for the given layer.

Steps taken to enable this functionality:

1. Modified the `model_gem_global.yml` configuration file to add a `dependencies` key that contains the name of the GeoMet layer on which the variable depends on. Also added a `bands_order` key that specifies the order in which the bands need to be created within the VRT. For example:
```yaml
        UGRD_ISBL_1000:
            [...]
            geomet_layers:
                GDPS.PRES_UGRD.1000:
                    forecast_hours: 000/240/PT3H
                GDPS.PRES_UU.1000:
                    dependencies:
                        - GDPS.PRES_VGRD.1000
                    forecast_hours: 000/240/PT3H
            bands_order:
                - UGRD_ISBL
                - VGRD_ISBL
```
2. When `model_gem_global.py` encounters a layer with dependencies, it checks that all dependencies listed are available in the tileindex for the same model run and forecast hour (see [L127](https://github.com/ECCC-MSC/geomet-data-registry/compare/master...Dukestep:uu-layers-gdps?expand=1#diff-5770a3fccda74a8fe7a62c1ef12135cbR127)). If all dependencies are found, items are created for this layer. The `wx_variable` property of the item is also modified to include the names of all variables used by the GeoMet layer. A VRT is created using the filepaths of the current variable and those of its dependencies. The `bands_order` for the variable can be passed to `VRTDataset` object in order to create the VRT with the bands in the specified order.

3. Time keys for the layer are only updated when all the layer's dependencies all have the same `default_model_run` value (see `model_gem_global.py` [L201](https://github.com/ECCC-MSC/geomet-data-registry/compare/master...Dukestep:uu-layers-gdps?expand=1#diff-5770a3fccda74a8fe7a62c1ef12135cbR201)).

Open to any suggestions and improvements. Keeping this as a WIP until we agree with the implementation.

This has been tested with a full GDPS model run and I have not identified any glaring issues.
