### PR TITLE
change class definitions to new style

### DIFF
--- a/geomet_data_registry/event.py
+++ b/geomet_data_registry/event.py
@@ -18,7 +18,7 @@
 ###############################################################################
 
 
-class Event(object):
+class Event:
     """core event"""
 
     def __init__(self, parent):

--- a/geomet_data_registry/handler/base.py
+++ b/geomet_data_registry/handler/base.py
@@ -22,7 +22,7 @@ import logging
 LOGGER = logging.getLogger(__name__)
 
 
-class BaseHandler(object):
+class BaseHandler:
     """base handler"""
 
     def __init__(self, filepath):

--- a/geomet_data_registry/layer/base.py
+++ b/geomet_data_registry/layer/base.py
@@ -28,7 +28,7 @@ from geomet_data_registry.util import get_today_and_now, VRTDataset, DATE_FORMAT
 LOGGER = logging.getLogger(__name__)
 
 
-class BaseLayer(object):
+class BaseLayer:
     """generic layer ABC"""
 
     def __init__(self, provider_def):

--- a/geomet_data_registry/store/base.py
+++ b/geomet_data_registry/store/base.py
@@ -22,7 +22,7 @@ import logging
 LOGGER = logging.getLogger(__name__)
 
 
-class BaseStore(object):
+class BaseStore:
     """generic key-value store ABC"""
 
     def __init__(self, provider_def):

--- a/geomet_data_registry/tileindex/base.py
+++ b/geomet_data_registry/tileindex/base.py
@@ -23,7 +23,7 @@ import os
 LOGGER = logging.getLogger(__name__)
 
 
-class BaseTileIndex(object):
+class BaseTileIndex:
     """generic Tile Index ABC"""
 
     def __init__(self, provider_def):


### PR DESCRIPTION
Removes redundant `object` parameter from class definitions throughout the codebase.

See https://docs.python.org/2/reference/datamodel.html#new-style-and-classic-classes for details regarding this change. By default, Python 3 only creates new style classes regardless of if the `object` parameter is passed or not.