### PR TITLE
[WIP] refactor and move add_time_key method to BaseLayer class

### DIFF
--- a/geomet_data_registry/layer/cgsl.py
+++ b/geomet_data_registry/layer/cgsl.py
@@ -103,16 +103,16 @@ class CgslLayer(BaseLayer):
                         forecast_hour_datetime.strftime(DATE_FORMAT))
         expected_count = self.file_dict[self.model]['variable'][self.wx_variable]['model_run'][self.model_run]['files_expected']  # noqa
 
-        for key, values in self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'].items():  # noqa
+        self.geomet_layers = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers']  # noqa
+        for key, values in self.geomet_layers.items():  # noqa
             layer_name = key
             identifier = '{}-{}-{}'.format(layer_name, str_mr, str_fh)
 
-            vrt = "vrt://{}?bands={}".format(filepath, values['bands'])
+            vrt = 'vrt://{}?bands={}'.format(filepath, values['bands'])
 
-            begin, end, interval = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'][key]['forecast_hours'].split('/')  # noqa
-            interval_num = re.sub('[^0-9]', '', interval)
-
-            fh = file_pattern_info['fh']
+            forecast_hours = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'][key]['forecast_hours']  # noqa
+            begin, end, interval = [int(re.sub('[^0-9]', '', value)) for value in forecast_hours.split('/')]  # noqa
+            fh = int(file_pattern_info['fh'])
 
             feature_dict = {
                 'layer_name': layer_name,
@@ -126,61 +126,16 @@ class CgslLayer(BaseLayer):
                 'expected_count': expected_count
             }
 
-            if (int(fh) == 0 and int(interval_num) == 0) or \
-               (int(fh) in range(int(begin), int(end) + 1, int(interval_num))):
+            if self.is_valid_interval(fh, begin, end, interval):
                 self.items.append(feature_dict)
+                self.layer_names.append(key)
             else:
-                LOGGER.debug('Forecast hour {} not included in {}/{}/{} as '
+                LOGGER.debug('Forecast hour {} not included in {} as '
                              'defined for variable {}. File will not be '
-                             'added to registry.'.format(fh, begin, end,
-                                                         interval,
+                             'added to registry.'.format(fh,
+                                                         forecast_hours,
                                                          self.wx_variable))
-
         return True
-
-    def add_time_key(self):
-        """
-        Add time keys when applicable:
-            - model run default time
-            - model run extent
-            - forecast hour extent
-        and for observation:
-            - latest time step
-        """
-
-        for key, values in self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'].items():  # noqa
-
-            time_extent_key = '{}_time_extent'.format(key)
-            start, end, interval = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'][key]['forecast_hours'].split('/')  # noqa
-            start_time = self.date_ + timedelta(hours=int(start))
-            end_time = self.date_ + timedelta(hours=int(end))
-            start_time = start_time.strftime(DATE_FORMAT)
-            end_time = end_time.strftime(DATE_FORMAT)
-            time_extent_value = '{}/{}/{}'.format(start_time,
-                                                  end_time,
-                                                  interval)
-
-            default_model_key = '{}_default_model_run'.format(key)
-            stored_default_model_run = self.store.get_key(default_model_key)
-
-            model_run_extent_key = '{}_model_run_extent'.format(key)
-            retention_hours = self.file_dict[self.model]['model_run_retention_hours']  # noqa
-            interval_hours = self.file_dict[self.model]['model_run_interval_hours']  # noqa
-            default_model_run = self.date_.strftime(DATE_FORMAT)
-            run_start_time = (self.date_ - timedelta(hours=retention_hours)).strftime(DATE_FORMAT)  # noqa
-            run_interval = 'PT{}H'.format(interval_hours)
-            model_run_extent_value = '{}/{}/{}'.format(run_start_time, default_model_run, run_interval)  # noqa
-
-            if stored_default_model_run and datetime.strptime(stored_default_model_run, DATE_FORMAT) > self.date_:  # noqa
-                LOGGER.debug("New default model run value ({}) is older than the current value in store: {}. "  # noqa
-                             "Not updating time keys.".format(default_model_run, stored_default_model_run))  # noqa
-                continue
-
-            LOGGER.debug('Adding time keys in the store')
-
-            self.store.set_key(time_extent_key, time_extent_value)
-            self.store.set_key(default_model_key, default_model_run)
-            self.store.set_key(model_run_extent_key, model_run_extent_value)
 
     def __repr__(self):
         return '<ModelCgslGlobalLayer> {}'.format(self.name)

--- a/geomet_data_registry/layer/geps.py
+++ b/geomet_data_registry/layer/geps.py
@@ -46,7 +46,6 @@ class GepsLayer(BaseLayer):
         provider_def = {'name': 'geps'}
         self.type = None
         self.bands = None
-        self.layer_names = []
 
         BaseLayer.__init__(self, provider_def)
 
@@ -95,6 +94,7 @@ class GepsLayer(BaseLayer):
         self.model_run_list = list(runs.keys())
 
         weather_var = self.file_dict[self.model][self.type]['variable'][self.wx_variable]  # noqa
+        self.geomet_layers = weather_var['geomet_layers']
 
         time_format = '%Y%m%d%H'
         self.date_ = datetime.strptime(file_pattern_info['time_'], time_format)
@@ -121,7 +121,7 @@ class GepsLayer(BaseLayer):
 
             expected_count = self.file_dict[self.model][self.type]['variable'][self.wx_variable]['model_run'][self.model_run]['files_expected']  # noqa
 
-            for layer in weather_var['geomet_layers'].keys():
+            for layer in self.geomet_layers.keys():
                 if self.type == 'member':
                     member = self.bands[band]['member']
                     layer_name = layer.format(self.bands[band]['member'])
@@ -144,59 +144,22 @@ class GepsLayer(BaseLayer):
                     'expected_count': expected_count
                 }
 
-                self.items.append(feature_dict)
-                self.layer_names.append(layer_name)
+                forecast_hours = self.file_dict[self.model][self.type]['variable'][self.wx_variable]['geomet_layers'][layer]['forecast_hours']  # noqa
+                begin, end, interval = [int(re.sub('[^0-9]', '', value)) for value in forecast_hours.split('/')]  # noqa
+                fh = int(file_pattern_info['fh'])
+
+                if self.is_valid_interval(fh, begin, end, interval):
+                    self.items.append(feature_dict)
+                    self.layer_names.append(layer_name)
+
+                else:
+                    LOGGER.debug('Forecast hour {} not included in {} as '
+                                 'defined for variable {}. File will not be '
+                                 'added to registry.'.format(fh,
+                                                             forecast_hours,
+                                                             self.wx_variable))
 
         return True
-
-    def add_time_key(self):
-        """
-        Add time keys when applicable:
-            - model run default time
-            - model run extent
-            - forecast hour extent
-        and for observation:
-            - latest time step
-        """
-
-        for key in self.layer_names:  # noqa
-
-            time_extent_key = '{}_time_extent'.format(key)
-
-            wx_info = self.file_dict[self.model][self.type]['variable'][self.wx_variable]  # noqa
-
-            for layer in wx_info['geomet_layers']:
-                if key.startswith(layer.format('')):
-                    start, end, interval = wx_info['geomet_layers'][layer]['forecast_hours'].split('/')  # noqa
-                    start_time = self.date_ + timedelta(hours=int(start))
-                    end_time = self.date_ + timedelta(hours=int(end))
-                    start_time = start_time.strftime(DATE_FORMAT)
-                    end_time = end_time.strftime(DATE_FORMAT)
-                    time_extent_value = '{}/{}/{}'.format(start_time,
-                                                          end_time,
-                                                          interval)
-
-            default_model_key = '{}_default_model_run'.format(key)
-            stored_default_model_run = self.store.get_key(default_model_key)
-
-            model_run_extent_key = '{}_model_run_extent'.format(key)
-            retention_hours = self.file_dict[self.model]['model_run_retention_hours']  # noqa
-            interval_hours = self.file_dict[self.model]['model_run_interval_hours']  # noqa
-            default_model_run = self.date_.strftime(DATE_FORMAT)
-            run_start_time = (self.date_ - timedelta(hours=retention_hours)).strftime(DATE_FORMAT)  # noqa
-            run_interval = 'PT{}H'.format(interval_hours)
-            model_run_extent_value = '{}/{}/{}'.format(run_start_time, default_model_run, run_interval)  # noqa
-
-            if stored_default_model_run and datetime.strptime(stored_default_model_run, DATE_FORMAT) > self.date_:  # noqa
-                LOGGER.debug("New default model run value ({}) is older than the current value in store: {}. "  # noqa
-                             "Not updating time keys.".format(default_model_run, stored_default_model_run))  # noqa
-                continue
-
-            LOGGER.debug('Adding time keys in the store')
-
-            self.store.set_key(time_extent_key, time_extent_value)
-            self.store.set_key(default_model_key, default_model_run)
-            self.store.set_key(model_run_extent_key, model_run_extent_value)
 
     def __repr__(self):
         return '<ModelGEPSLayer> {}'.format(self.name)

--- a/geomet_data_registry/layer/model_gem_regional.py
+++ b/geomet_data_registry/layer/model_gem_regional.py
@@ -103,14 +103,14 @@ class ModelGemRegionalLayer(BaseLayer):
                         forecast_hour_datetime.strftime(DATE_FORMAT))
         expected_count = self.file_dict[self.model]['variable'][self.wx_variable]['model_run'][self.model_run]['files_expected']  # noqa
 
-        for key, values in self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'].items():  # noqa
+        self.geomet_layers = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers']  # noqa
+        for key, values in self.geomet_layers.items():  # noqa
             layer_name = key
             identifier = '{}-{}-{}'.format(layer_name, str_mr, str_fh)
 
-            begin, end, interval = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'][key]['forecast_hours'][self.model_run].split('/')  # noqa
-            interval_num = re.sub('[^0-9]', '', interval)
-
-            fh = file_pattern_info['fh']
+            forecast_hours = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'][key]['forecast_hours'][self.model_run]  # noqa
+            begin, end, interval = [int(re.sub('[^0-9]', '', value)) for value in forecast_hours.split('/')]  # noqa
+            fh = int(file_pattern_info['fh'])
 
             feature_dict = {
                 'layer_name': layer_name,
@@ -124,61 +124,18 @@ class ModelGemRegionalLayer(BaseLayer):
                 'expected_count': expected_count
             }
 
-            if (int(fh) == 0 and int(interval_num) == 0) or \
-               (int(fh) in range(int(begin), int(end) + 1, int(interval_num))):
+            if self.is_valid_interval(fh, begin, end, interval):
                 self.items.append(feature_dict)
+                self.layer_names.append(key)
+
             else:
-                LOGGER.debug('Forecast hour {} not included in {}/{}/{} as '
-                             ' defined for variable {}. File will not be '
-                             'added to registry.'.format(fh, begin, end,
-                                                         interval,
+                LOGGER.debug('Forecast hour {} not included in {} as '
+                             'defined for variable {}. File will not be '
+                             'added to registry.'.format(fh,
+                                                         forecast_hours,
                                                          self.wx_variable))
 
         return True
-
-    def add_time_key(self):
-        """
-        Add time keys when applicable:
-            - model run default time
-            - model run extent
-            - forecast hour extent
-        and for observation:
-            - latest time step
-        """
-
-        for key, values in self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'].items():  # noqa
-
-            time_extent_key = '{}_time_extent'.format(key)
-            start, end, interval = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'][key]['forecast_hours'][self.model_run].split('/')  # noqa
-            start_time = self.date_ + timedelta(hours=int(start))
-            end_time = self.date_ + timedelta(hours=int(end))
-            start_time = start_time.strftime(DATE_FORMAT)
-            end_time = end_time.strftime(DATE_FORMAT)
-            time_extent_value = '{}/{}/{}'.format(start_time,
-                                                  end_time,
-                                                  interval)
-
-            default_model_key = '{}_default_model_run'.format(key)
-            stored_default_model_run = self.store.get_key(default_model_key)
-
-            model_run_extent_key = '{}_model_run_extent'.format(key)
-            retention_hours = self.file_dict[self.model]['model_run_retention_hours']  # noqa
-            interval_hours = self.file_dict[self.model]['model_run_interval_hours']  # noqa
-            default_model_run = self.date_.strftime(DATE_FORMAT)
-            run_start_time = (self.date_ - timedelta(hours=retention_hours)).strftime(DATE_FORMAT)  # noqa
-            run_interval = 'PT{}H'.format(interval_hours)
-            model_run_extent_value = '{}/{}/{}'.format(run_start_time, default_model_run, run_interval)  # noqa
-
-            if stored_default_model_run and datetime.strptime(stored_default_model_run, DATE_FORMAT) > self.date_:  # noqa
-                LOGGER.debug("New default model run value ({}) is older than the current value in store: {}. "  # noqa
-                             "Not updating time keys.".format(default_model_run, stored_default_model_run))  # noqa
-                continue
-
-            LOGGER.debug('Adding time keys in the store')
-
-            self.store.set_key(time_extent_key, time_extent_value)
-            self.store.set_key(default_model_key, default_model_run)
-            self.store.set_key(model_run_extent_key, model_run_extent_value)
 
     def __repr__(self):
         return '<ModelGemRegionalLayer> {}'.format(self.name)

--- a/geomet_data_registry/layer/model_hrdps_continental.py
+++ b/geomet_data_registry/layer/model_hrdps_continental.py
@@ -102,14 +102,14 @@ class ModelHrdpsContinentalLayer(BaseLayer):
                         forecast_hour_datetime.strftime(DATE_FORMAT))
         expected_count = self.file_dict[self.model]['variable'][self.wx_variable]['model_run'][self.model_run]['files_expected']  # noqa
 
-        for key, values in self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'].items():  # noqa
+        self.geomet_layers = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers']  # noqa
+        for key, values in self.geomet_layers.items():  # noqa
             layer_name = key
             identifier = '{}-{}-{}'.format(layer_name, str_mr, str_fh)
 
-            begin, end, interval = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'][key]['forecast_hours'].split('/')  # noqa
-            interval_num = re.sub('[^0-9]', '', interval)
-
-            fh = file_pattern_info['fh']
+            forecast_hours = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'][key]['forecast_hours']   # noqa
+            begin, end, interval = [int(re.sub('[^0-9]', '', value)) for value in forecast_hours.split('/')]  # noqa
+            fh = int(file_pattern_info['fh'])
 
             feature_dict = {
                 'layer_name': layer_name,
@@ -123,60 +123,17 @@ class ModelHrdpsContinentalLayer(BaseLayer):
                 'expected_count': expected_count
             }
 
-            if (int(fh) == 0 and int(interval_num) == 0) or \
-               (int(fh) in range(int(begin), int(end) + 1, int(interval_num))):
+            if self.is_valid_interval(fh, begin, end, interval):
                 self.items.append(feature_dict)
+                self.layer_names.append(key)
+
             else:
-                LOGGER.debug('Forecast hour {} not included in {}/{}/{} as '
-                             'defined for variable {}. File will not be added'
-                             ' to registry.'.format(fh, begin, end, interval,
-                                                    self.wx_variable))
-
+                LOGGER.debug('Forecast hour {} not included in {} as '
+                             'defined for variable {}. File will not be '
+                             'added to registry.'.format(fh,
+                                                         forecast_hours,
+                                                         self.wx_variable))
         return True
-
-    def add_time_key(self):
-        """
-        Add time keys when applicable:
-            - model run default time
-            - model run extent
-            - forecast hour extent
-        and for observation:
-            - latest time step
-        """
-
-        for key, values in self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'].items():  # noqa
-
-            time_extent_key = '{}_time_extent'.format(key)
-            start, end, interval = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'][key]['forecast_hours'].split('/')  # noqa
-            start_time = self.date_ + timedelta(hours=int(start))
-            end_time = self.date_ + timedelta(hours=int(end))
-            start_time = start_time.strftime(DATE_FORMAT)
-            end_time = end_time.strftime(DATE_FORMAT)
-            time_extent_value = '{}/{}/{}'.format(start_time,
-                                                  end_time,
-                                                  interval)
-
-            default_model_key = '{}_default_model_run'.format(key)
-            stored_default_model_run = self.store.get_key(default_model_key)
-
-            model_run_extent_key = '{}_model_run_extent'.format(key)
-            retention_hours = self.file_dict[self.model]['model_run_retention_hours']  # noqa
-            interval_hours = self.file_dict[self.model]['model_run_interval_hours']  # noqa
-            default_model_run = self.date_.strftime(DATE_FORMAT)
-            run_start_time = (self.date_ - timedelta(hours=retention_hours)).strftime(DATE_FORMAT)  # noqa
-            run_interval = 'PT{}H'.format(interval_hours)
-            model_run_extent_value = '{}/{}/{}'.format(run_start_time, default_model_run, run_interval)  # noqa
-
-            if stored_default_model_run and datetime.strptime(stored_default_model_run, DATE_FORMAT) > self.date_:  # noqa
-                LOGGER.debug("New default model run value ({}) is older than the current value in store: {}. "  # noqa
-                             "Not updating time keys.".format(default_model_run, stored_default_model_run))  # noqa
-                continue
-
-            LOGGER.debug('Adding time keys in the store')
-
-            self.store.set_key(time_extent_key, time_extent_value)
-            self.store.set_key(default_model_key, default_model_run)
-            self.store.set_key(model_run_extent_key, model_run_extent_value)
 
     def __repr__(self):
         return '<ModelHrdpsContinentalLayer> {}'.format(self.name)

--- a/geomet_data_registry/layer/radar_1km.py
+++ b/geomet_data_registry/layer/radar_1km.py
@@ -110,12 +110,9 @@ class Radar1kmLayer(BaseLayer):
 
     def add_time_key(self):
         """
-        Add time keys when applicable:
-            - model run default time
-            - model run extent
-            - forecast hour extent
-        and for observation:
-            - latest time step
+        Adds default time and time extent datetime values to store for radar
+        layers. Overrides the add_time_key method of BaseLayer class due to
+        radar data's lack of forecast models.
         """
 
         layer_name = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layer'] # noqa

--- a/geomet_data_registry/util.py
+++ b/geomet_data_registry/util.py
@@ -64,8 +64,9 @@ class VRTDataset:
         :returns: `str` of VRT.
         """
         if self.bands_order:
+            LOGGER.debug("Sorting filepaths against provided bands order.")
             self.filepaths = sorted(self.filepaths,
-                                    key=lambda fp:self.sort_band(fp))
+                                    key=lambda fp: self.sort_band(fp))
 
         for index, filepath in enumerate(self.filepaths, start=1):
             self.vrt_dataset.insert(-1, self.vrt_raster_band_template.format(
@@ -79,9 +80,8 @@ class VRTDataset:
         :returns: `int` of new filepath position in relation to
         self.bands_order
         """
-        LOGGER.debug("Checking filepath against provided bands order.")
         filepath_postion = [idx for idx, value in enumerate(self.bands_order)
-                if value in filepath]
+                            if value in filepath]
         if len(filepath_postion) != 1:
             msg = "Band order could not be determined. Band order values do" \
                   " not match filepath or filepath matches several band " \
@@ -98,7 +98,7 @@ class VRTDataset:
         """
         formatted_vrt = ''
         for item in self.vrt_dataset:
-            formatted_vrt += dedent(re.sub('>\s+<', '><', item))
+            formatted_vrt += dedent(re.sub(r'>\s+<', '><', item))
 
         return formatted_vrt
 


### PR DESCRIPTION
This pull requests moves the `add_time_key` method implemented by each model into the `BaseLayer` class in order to avoid some repetition in our code.

The radar handler overwrites the method due to it's own particular characteristics (e.g. no model runs).

Also included in this PR:

- Minor changes to `VRTDataset` util class (changed logger debug messages and add `r` to string literal for regex).
- Created `is_valid_interval()` static method in `BaseLayer` used by many model handlers to check if the incoming file is a valid time step as per the `forecast_hours` defined for that variable in its respective configuration file.
- Removal of some double quotes.