### PR TITLE
refactor and move add_time_key method to BaseLayer class

### DIFF
--- a/conf/model_giops.yml
+++ b/conf/model_giops.yml
@@ -10,7 +10,7 @@ model_giops:
                 elevation: surface
                 model_run:
                     00Z:
-                        files_expected: 81
+                        files_expected: 80
                     12Z:
                         files_expected: 80
                 geomet_layers:
@@ -54,7 +54,7 @@ model_giops:
                 elevation: surface
                 model_run:
                     00Z:
-                        files_expected: 81
+                        files_expected: 80
                     12Z:
                         files_expected: 80
                 geomet_layers:
@@ -65,7 +65,7 @@ model_giops:
                 elevation: surface
                 model_run:
                     00Z:
-                        files_expected: 81
+                        files_expected: 80
                     12Z:
                         files_expected: 80
                 geomet_layers:
@@ -283,7 +283,7 @@ model_giops:
                 members: null
                 model_run:
                     00Z:
-                        files_expected: 11
+                        files_expected: 10
                     12Z:
                         files_expected: 10
                 geomet_layers:
@@ -444,7 +444,7 @@ model_giops:
                 members: null
                 model_run:
                     00Z:
-                        files_expected: 11
+                        files_expected: 10
                     12Z:
                         files_expected: 10
                 geomet_layers:

--- a/geomet_data_registry/layer/base.py
+++ b/geomet_data_registry/layer/base.py
@@ -17,13 +17,14 @@
 #
 ###############################################################################
 
-from datetime import datetime
+from datetime import datetime, timedelta
 import logging
 import os
 
 from geomet_data_registry.env import STORE_PROVIDER_DEF, TILEINDEX_PROVIDER_DEF
 from geomet_data_registry.plugin import load_plugin
-from geomet_data_registry.util import get_today_and_now, VRTDataset, DATE_FORMAT
+from geomet_data_registry.util import (get_today_and_now, VRTDataset,
+                                       DATE_FORMAT)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -52,6 +53,7 @@ class BaseLayer:
         self.dimensions = None
         self.model = None
         self.model_run = None
+        self.geomet_layers = None
         self.wx_variable = None
         self.date_ = None
         self.file_dict = None
@@ -77,27 +79,26 @@ class BaseLayer:
     def register(self):
         """
         Registers a file into the system
-
         :returns: `bool` of status result
         """
-
-        if len(self.items) > 1:
+        items = [item for item in self.items if item['register_status']]
+        if len(items) > 1:
             item_bulk = []
-            for item in self.items:
+            for item in items:
                 item_bulk.append(self.layer2dict(item))
             LOGGER.debug('Adding to tileindex (bulk)')
             r = self.tileindex.bulk_add(item_bulk)
-            status = r[self.items[0]['identifier']]
+            status = r[items[0]['identifier']]
             item_dict = item_bulk[0]
-            self.update_count(self.items[0], status, item_dict)
-        elif len(self.items) == 1:
-            item = self.items[0]
+            self.update_count(items[0], status, item_dict)
+        elif len(items) == 1:
+            item = items[0]
             LOGGER.debug('Adding item {}'.format(item['identifier']))
             item_dict = self.layer2dict(item)
             LOGGER.debug('Adding to tileindex')
             r = self.tileindex.add(item_dict['properties']['identifier'],
                                    item_dict)
-            self.update_count(self.items[0], r, item_dict)
+            self.update_count(items[0], r, item_dict)
         else:
             LOGGER.error('Empty item list for {}'.format(self.filepath))
             return False
@@ -194,7 +195,7 @@ class BaseLayer:
                                                    item['expected_count'],
                                                    item['layer_name']))
                         self.store.set_key(layer_count_key_reset, 0)
-        else:
+        elif r == 201:
             self.new_key_store = True
 
     def check_layer_dependencies(self, layers_list, str_mr, str_fh):
@@ -205,7 +206,7 @@ class BaseLayer:
         :param str_mr: `str` of model run
         :param str_fh: `str` of forecast hour
         :returns: `list` of GeoJSON objects for all retrieved dependencies if
-        all dependencies are found otherwise returns an empty list
+                   all dependencies are found otherwise returns an empty list
         """
         dependencies = [self.tileindex.get('{}-{}-{}'.format(
             layer, str_mr, str_fh)) for layer in layers_list]  # noqa
@@ -225,7 +226,7 @@ class BaseLayer:
         :param dependencies: `list` of GeoJSON objects from tileindex
         :param image_dimension: `dict` with x and y keys
         :param bands_order: `list` of variables order in VRT
-        :returns: `list` with VRT and combined weather variables as string
+        :returns: `tuple` of VRT and combined weather variables as string
         """
         filepaths = [self.filepath] + [dependency['properties']
                                        ['filepath'] for dependency
@@ -250,7 +251,7 @@ class BaseLayer:
         :param dependencies: `list` of dependencies to check
         :param mr_datetime: `datetime` to compare dependencies to
         :returns: `bool` indicating if all dependencies'
-        default model run is equal to the passed mr_datetime param
+                  default model run is equal to the passed mr_datetime param
         """
         results = [datetime.strptime(default_mr, DATE_FORMAT) == mr_datetime
                    if default_mr is not None else False
@@ -259,15 +260,83 @@ class BaseLayer:
                                       for layer in dependencies]]
         return all(results)
 
+    @staticmethod
+    def is_valid_interval(fh, begin, end, interval):
+        """
+        Checks if a passed forecast hour is valid given begin, end and interval
+        parameters. If the forecast hour is 0 and the interval is 0, the
+        forecast hour is also considered valid (since Python's range function
+        does not accept 0 as an interval).
+        :param fh: `int` of forecast hour
+        :param begin: `int` of forecast hour begin
+        :param end: `int` of forecast hour end
+        :param interval: `int` of forecast hour interval
+        :returns: `bool` representing if the passed forecast hour is contained
+                   in the passed begin/end/interval range
+        """
+
+        return any([fh == 0 and interval == 0,
+                    fh in range(begin, end + 1, interval) if interval != 0
+                    else False])
+
     def add_time_key(self):
         """
-        Add time keys when applicable:
-            - model run default time
-            - model run extent
-            - forecast hour extent
-        and for observation:
-            - latest time step
+        Adds time keys (time extent, default model run and model runs extent,
+        to store for layers included in self.items (a list of GeoMet
+        layers modified/updated by an incoming received weather
+        variable).
+        :returns: `bool` if layers had their time keys updated successfully
         """
+        for item in self.items:
+
+            time_extent_key = '{}_time_extent'.format(item['layer_name'])
+
+            start_time = self.date_ + timedelta(
+                hours=item['forecast_hours']['begin'])
+            end_time = self.date_ + timedelta(
+                hours=item['forecast_hours']['end'])
+
+            start_time = start_time.strftime(DATE_FORMAT)
+            end_time = end_time.strftime(DATE_FORMAT)
+            time_extent_value = '{}/{}/{}'.format(start_time,
+                                                  end_time,
+                                                  item['forecast_hours']
+                                                  ['interval'])
+
+            default_model_key = '{}_default_model_run'.format(item['layer_name'])
+            stored_default_model_run = self.store.get_key(default_model_key)
+
+            model_run_extent_key = '{}_model_run_extent'.format(item['layer_name'])  # noqa
+            retention_hours = self.file_dict[self.model]['model_run_retention_hours']  # noqa
+            interval_hours = self.file_dict[self.model]['model_run_interval_hours']  # noqa
+            default_model_run = self.date_.strftime(DATE_FORMAT)
+            run_start_time = (self.date_ - timedelta(hours=retention_hours)).strftime(DATE_FORMAT)  # noqa
+            run_interval = 'PT{}H'.format(interval_hours)
+            model_run_extent_value = '{}/{}/{}'.format(run_start_time, default_model_run, run_interval)  # noqa
+
+            if stored_default_model_run and datetime.strptime(stored_default_model_run, DATE_FORMAT) > self.date_:  # noqa
+                LOGGER.debug('New default model run value ({}) is older than the current value in store: {}. '  # noqa
+                             'Not updating time keys.'.format(default_model_run, stored_default_model_run))  # noqa
+                continue
+
+            if 'dependencies' in item['layer_config']:
+                if not self.check_dependencies_default_mr(
+                        self.date_, item['layer_config']['dependencies']):
+                    LOGGER.debug(
+                        'The default model run for at least one '
+                        'dependency does not match. '
+                        'Not updating time keys for {}'.format(
+                            item['layer_name'])
+                    )
+                    continue
+
+            LOGGER.debug('Adding time keys in the store')
+
+            self.store.set_key(time_extent_key, time_extent_value)
+            self.store.set_key(default_model_key, default_model_run)
+            self.store.set_key(model_run_extent_key, model_run_extent_value)
+
+        return True
 
     def __repr__(self):
         return '<BaseLayer> {}'.format(self.name)

--- a/geomet_data_registry/layer/cgsl.py
+++ b/geomet_data_registry/layer/cgsl.py
@@ -103,16 +103,16 @@ class CgslLayer(BaseLayer):
                         forecast_hour_datetime.strftime(DATE_FORMAT))
         expected_count = self.file_dict[self.model]['variable'][self.wx_variable]['model_run'][self.model_run]['files_expected']  # noqa
 
-        for key, values in self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'].items():  # noqa
-            layer_name = key
+        self.geomet_layers = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers']  # noqa
+        for layer_name, layer_config in self.geomet_layers.items():  # noqa
             identifier = '{}-{}-{}'.format(layer_name, str_mr, str_fh)
 
-            vrt = "vrt://{}?bands={}".format(filepath, values['bands'])
+            vrt = 'vrt://{}?bands={}'.format(filepath, layer_config['bands'])
 
-            begin, end, interval = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'][key]['forecast_hours'].split('/')  # noqa
-            interval_num = re.sub('[^0-9]', '', interval)
-
-            fh = file_pattern_info['fh']
+            forecast_hours = layer_config['forecast_hours']
+            begin, end, interval = [int(re.sub('[^0-9]', '', value))
+                                    for value in forecast_hours.split('/')]
+            fh = int(file_pattern_info['fh'])
 
             feature_dict = {
                 'layer_name': layer_name,
@@ -123,64 +123,26 @@ class CgslLayer(BaseLayer):
                 'member': member,
                 'model': self.model,
                 'elevation': elevation,
-                'expected_count': expected_count
+                'expected_count': expected_count,
+                'forecast_hours': {
+                    'begin': begin,
+                    'end': end,
+                    'interval': forecast_hours.split('/')[2]
+                },
+                'layer_config': layer_config,
+                'register_status': True,
             }
 
-            if (int(fh) == 0 and int(interval_num) == 0) or \
-               (int(fh) in range(int(begin), int(end) + 1, int(interval_num))):
-                self.items.append(feature_dict)
-            else:
-                LOGGER.debug('Forecast hour {} not included in {}/{}/{} as '
-                             'defined for variable {}. File will not be '
-                             'added to registry.'.format(fh, begin, end,
-                                                         interval,
-                                                         self.wx_variable))
+            if not self.is_valid_interval(fh, begin, end, interval):
+                feature_dict['register_status'] = False
+                LOGGER.debug('Forecast hour {} not included in {} as '
+                             'defined for layer {}. File will not be '
+                             'added to registry for this layer'
+                             .format(fh, forecast_hours, layer_name))
+
+            self.items.append(feature_dict)
 
         return True
-
-    def add_time_key(self):
-        """
-        Add time keys when applicable:
-            - model run default time
-            - model run extent
-            - forecast hour extent
-        and for observation:
-            - latest time step
-        """
-
-        for key, values in self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'].items():  # noqa
-
-            time_extent_key = '{}_time_extent'.format(key)
-            start, end, interval = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'][key]['forecast_hours'].split('/')  # noqa
-            start_time = self.date_ + timedelta(hours=int(start))
-            end_time = self.date_ + timedelta(hours=int(end))
-            start_time = start_time.strftime(DATE_FORMAT)
-            end_time = end_time.strftime(DATE_FORMAT)
-            time_extent_value = '{}/{}/{}'.format(start_time,
-                                                  end_time,
-                                                  interval)
-
-            default_model_key = '{}_default_model_run'.format(key)
-            stored_default_model_run = self.store.get_key(default_model_key)
-
-            model_run_extent_key = '{}_model_run_extent'.format(key)
-            retention_hours = self.file_dict[self.model]['model_run_retention_hours']  # noqa
-            interval_hours = self.file_dict[self.model]['model_run_interval_hours']  # noqa
-            default_model_run = self.date_.strftime(DATE_FORMAT)
-            run_start_time = (self.date_ - timedelta(hours=retention_hours)).strftime(DATE_FORMAT)  # noqa
-            run_interval = 'PT{}H'.format(interval_hours)
-            model_run_extent_value = '{}/{}/{}'.format(run_start_time, default_model_run, run_interval)  # noqa
-
-            if stored_default_model_run and datetime.strptime(stored_default_model_run, DATE_FORMAT) > self.date_:  # noqa
-                LOGGER.debug("New default model run value ({}) is older than the current value in store: {}. "  # noqa
-                             "Not updating time keys.".format(default_model_run, stored_default_model_run))  # noqa
-                continue
-
-            LOGGER.debug('Adding time keys in the store')
-
-            self.store.set_key(time_extent_key, time_extent_value)
-            self.store.set_key(default_model_key, default_model_run)
-            self.store.set_key(model_run_extent_key, model_run_extent_value)
 
     def __repr__(self):
         return '<ModelCgslGlobalLayer> {}'.format(self.name)

--- a/geomet_data_registry/layer/geps.py
+++ b/geomet_data_registry/layer/geps.py
@@ -46,7 +46,6 @@ class GepsLayer(BaseLayer):
         provider_def = {'name': 'geps'}
         self.type = None
         self.bands = None
-        self.layer_names = []
 
         BaseLayer.__init__(self, provider_def)
 
@@ -95,6 +94,7 @@ class GepsLayer(BaseLayer):
         self.model_run_list = list(runs.keys())
 
         weather_var = self.file_dict[self.model][self.type]['variable'][self.wx_variable]  # noqa
+        self.geomet_layers = weather_var['geomet_layers']
 
         time_format = '%Y%m%d%H'
         self.date_ = datetime.strptime(file_pattern_info['time_'], time_format)
@@ -121,7 +121,7 @@ class GepsLayer(BaseLayer):
 
             expected_count = self.file_dict[self.model][self.type]['variable'][self.wx_variable]['model_run'][self.model_run]['files_expected']  # noqa
 
-            for layer in weather_var['geomet_layers'].keys():
+            for layer, layer_config in self.geomet_layers.items():
                 if self.type == 'member':
                     member = self.bands[band]['member']
                     layer_name = layer.format(self.bands[band]['member'])
@@ -132,8 +132,15 @@ class GepsLayer(BaseLayer):
 
                 identifier = '{}-{}-{}'.format(layer_name, str_mr, str_fh)
 
+                forecast_hours = layer_config['forecast_hours']
+                begin, end, interval = [int(re.sub('[^0-9]', '', value))
+                                        for value in
+                                        forecast_hours.split('/')]
+                fh = int(file_pattern_info['fh'])
+
                 feature_dict = {
                     'layer_name': layer_name,
+                    'layer_name_unformatted': layer,
                     'filepath': vrt,
                     'identifier': identifier,
                     'reference_datetime': reference_datetime.strftime(DATE_FORMAT),  # noqa
@@ -141,62 +148,26 @@ class GepsLayer(BaseLayer):
                     'member': member,
                     'model': self.model,
                     'elevation': elevation,
-                    'expected_count': expected_count
+                    'expected_count': expected_count,
+                    'forecast_hours': {
+                        'begin': begin,
+                        'end': end,
+                        'interval': forecast_hours.split('/')[2]
+                    },
+                    'layer_config': layer_config,
+                    'register_status': True,
                 }
 
+                if not self.is_valid_interval(fh, begin, end, interval):
+                    feature_dict['register_status'] = False
+                    LOGGER.debug('Forecast hour {} not included in {} as '
+                                 'defined for layer {}. File will not be '
+                                 'added to registry for this layer'
+                                 .format(fh, forecast_hours, layer_name))
+
                 self.items.append(feature_dict)
-                self.layer_names.append(layer_name)
 
         return True
-
-    def add_time_key(self):
-        """
-        Add time keys when applicable:
-            - model run default time
-            - model run extent
-            - forecast hour extent
-        and for observation:
-            - latest time step
-        """
-
-        for key in self.layer_names:  # noqa
-
-            time_extent_key = '{}_time_extent'.format(key)
-
-            wx_info = self.file_dict[self.model][self.type]['variable'][self.wx_variable]  # noqa
-
-            for layer in wx_info['geomet_layers']:
-                if key.startswith(layer.format('')):
-                    start, end, interval = wx_info['geomet_layers'][layer]['forecast_hours'].split('/')  # noqa
-                    start_time = self.date_ + timedelta(hours=int(start))
-                    end_time = self.date_ + timedelta(hours=int(end))
-                    start_time = start_time.strftime(DATE_FORMAT)
-                    end_time = end_time.strftime(DATE_FORMAT)
-                    time_extent_value = '{}/{}/{}'.format(start_time,
-                                                          end_time,
-                                                          interval)
-
-            default_model_key = '{}_default_model_run'.format(key)
-            stored_default_model_run = self.store.get_key(default_model_key)
-
-            model_run_extent_key = '{}_model_run_extent'.format(key)
-            retention_hours = self.file_dict[self.model]['model_run_retention_hours']  # noqa
-            interval_hours = self.file_dict[self.model]['model_run_interval_hours']  # noqa
-            default_model_run = self.date_.strftime(DATE_FORMAT)
-            run_start_time = (self.date_ - timedelta(hours=retention_hours)).strftime(DATE_FORMAT)  # noqa
-            run_interval = 'PT{}H'.format(interval_hours)
-            model_run_extent_value = '{}/{}/{}'.format(run_start_time, default_model_run, run_interval)  # noqa
-
-            if stored_default_model_run and datetime.strptime(stored_default_model_run, DATE_FORMAT) > self.date_:  # noqa
-                LOGGER.debug("New default model run value ({}) is older than the current value in store: {}. "  # noqa
-                             "Not updating time keys.".format(default_model_run, stored_default_model_run))  # noqa
-                continue
-
-            LOGGER.debug('Adding time keys in the store')
-
-            self.store.set_key(time_extent_key, time_extent_value)
-            self.store.set_key(default_model_key, default_model_run)
-            self.store.set_key(model_run_extent_key, model_run_extent_value)
 
     def __repr__(self):
         return '<ModelGEPSLayer> {}'.format(self.name)

--- a/geomet_data_registry/layer/model_gem_global.py
+++ b/geomet_data_registry/layer/model_gem_global.py
@@ -105,14 +105,14 @@ class ModelGemGlobalLayer(BaseLayer):
                         forecast_hour_datetime.strftime(DATE_FORMAT))
         expected_count = self.file_dict[self.model]['variable'][self.wx_variable]['model_run'][self.model_run]['files_expected']  # noqa
 
-        for key, values in self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'].items():  # noqa
-            layer_name = key
+        self.geomet_layers = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers']  # noqa
+        for layer_name, layer_config in self.geomet_layers.items():
             identifier = '{}-{}-{}'.format(layer_name, str_mr, str_fh)
 
-            begin, end, interval = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'][key]['forecast_hours'].split('/')  # noqa
-            interval_num = re.sub('[^0-9]', '', interval)
-
-            fh = file_pattern_info['fh']
+            forecast_hours = layer_config['forecast_hours']
+            begin, end, interval = [int(re.sub('[^0-9]', '', value))
+                                    for value in forecast_hours.split('/')]
+            fh = int(file_pattern_info['fh'])
 
             feature_dict = {
                 'layer_name': layer_name,
@@ -123,12 +123,19 @@ class ModelGemGlobalLayer(BaseLayer):
                 'member': member,
                 'model': self.model,
                 'elevation': elevation,
-                'expected_count': expected_count
+                'expected_count': expected_count,
+                'forecast_hours': {
+                    'begin': begin,
+                    'end': end,
+                    'interval': forecast_hours.split('/')[2]
+                },
+                'layer_config': layer_config,
+                'register_status': True,
             }
 
-            if 'dependencies' in values:
+            if 'dependencies' in layer_config:
                 dependencies_found = self.check_layer_dependencies(
-                    values['dependencies'],
+                    layer_config['dependencies'],
                     str_mr,
                     str_fh)
                 if dependencies_found:
@@ -142,73 +149,20 @@ class ModelGemGlobalLayer(BaseLayer):
                             self.dimensions,
                             bands_order))
                 else:
+                    feature_dict['register_status'] = False
+                    self.items.append(feature_dict)
                     continue
 
-            if (int(fh) == 0 and int(interval_num) == 0) or \
-               (int(fh) in range(int(begin), int(end) + 1, int(interval_num))):
-                self.items.append(feature_dict)
-            else:
-                LOGGER.debug('Forecast hour {} not included in {}/{}/{} as '
-                             'defined for variable {}. File will not be '
-                             'added to registry.'.format(fh, begin, end,
-                                                         interval,
-                                                         self.wx_variable))
+            if not self.is_valid_interval(fh, begin, end, interval):
+                feature_dict['register_status'] = False
+                LOGGER.debug('Forecast hour {} not included in {} as '
+                             'defined for layer {}. File will not be '
+                             'added to registry for this layer'
+                             .format(fh, forecast_hours, layer_name))
+
+            self.items.append(feature_dict)
 
         return True
-
-    def add_time_key(self):
-        """
-        Add time keys when applicable:
-            - model run default time
-            - model run extent
-            - forecast hour extent
-        and for observation:
-            - latest time step
-        """
-
-        for key, values in self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'].items():  # noqa
-
-            time_extent_key = '{}_time_extent'.format(key)
-            start, end, interval = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'][key]['forecast_hours'].split('/')  # noqa
-            start_time = self.date_ + timedelta(hours=int(start))
-            end_time = self.date_ + timedelta(hours=int(end))
-            start_time = start_time.strftime(DATE_FORMAT)
-            end_time = end_time.strftime(DATE_FORMAT)
-            time_extent_value = '{}/{}/{}'.format(start_time,
-                                                  end_time,
-                                                  interval)
-
-            default_model_key = '{}_default_model_run'.format(key)
-            stored_default_model_run = self.store.get_key(default_model_key)
-
-            model_run_extent_key = '{}_model_run_extent'.format(key)
-            retention_hours = self.file_dict[self.model]['model_run_retention_hours']  # noqa
-            interval_hours = self.file_dict[self.model]['model_run_interval_hours']  # noqa
-            default_model_run = self.date_.strftime(DATE_FORMAT)
-            run_start_time = (self.date_ - timedelta(hours=retention_hours)).strftime(DATE_FORMAT)  # noqa
-            run_interval = 'PT{}H'.format(interval_hours)
-            model_run_extent_value = '{}/{}/{}'.format(run_start_time, default_model_run, run_interval)  # noqa
-
-            if stored_default_model_run and datetime.strptime(stored_default_model_run, DATE_FORMAT) > self.date_:  # noqa
-                LOGGER.debug('New default model run value ({}) is older than the current value in store: {}. '  # noqa
-                             'Not updating time keys.'.format(default_model_run, stored_default_model_run))  # noqa
-                continue
-
-            if 'dependencies' in values:
-                if not self.check_dependencies_default_mr(
-                        self.date_, values['dependencies']):
-                    LOGGER.debug(
-                        'The default model run for at least one '
-                        'dependency does not match. '
-                        'Not updating time keys for {}'.format(key)
-                    )
-                    continue
-
-            LOGGER.debug('Adding time keys in the store')
-
-            self.store.set_key(time_extent_key, time_extent_value)
-            self.store.set_key(default_model_key, default_model_run)
-            self.store.set_key(model_run_extent_key, model_run_extent_value)
 
     def __repr__(self):
         return '<ModelGemGlobalLayer> {}'.format(self.name)

--- a/geomet_data_registry/layer/model_gem_regional.py
+++ b/geomet_data_registry/layer/model_gem_regional.py
@@ -103,14 +103,14 @@ class ModelGemRegionalLayer(BaseLayer):
                         forecast_hour_datetime.strftime(DATE_FORMAT))
         expected_count = self.file_dict[self.model]['variable'][self.wx_variable]['model_run'][self.model_run]['files_expected']  # noqa
 
-        for key, values in self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'].items():  # noqa
-            layer_name = key
+        self.geomet_layers = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers']  # noqa
+        for layer_name, layer_config in self.geomet_layers.items():  # noqa
             identifier = '{}-{}-{}'.format(layer_name, str_mr, str_fh)
 
-            begin, end, interval = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'][key]['forecast_hours'][self.model_run].split('/')  # noqa
-            interval_num = re.sub('[^0-9]', '', interval)
-
-            fh = file_pattern_info['fh']
+            forecast_hours = layer_config['forecast_hours'][self.model_run]
+            begin, end, interval = [int(re.sub('[^0-9]', '', value))
+                                    for value in forecast_hours.split('/')]
+            fh = int(file_pattern_info['fh'])
 
             feature_dict = {
                 'layer_name': layer_name,
@@ -121,64 +121,26 @@ class ModelGemRegionalLayer(BaseLayer):
                 'member': member,
                 'model': self.model,
                 'elevation': elevation,
-                'expected_count': expected_count
+                'expected_count': expected_count,
+                'forecast_hours': {
+                    'begin': begin,
+                    'end': end,
+                    'interval': forecast_hours.split('/')[2]
+                },
+                'layer_config': layer_config,
+                'register_status': True,
             }
 
-            if (int(fh) == 0 and int(interval_num) == 0) or \
-               (int(fh) in range(int(begin), int(end) + 1, int(interval_num))):
-                self.items.append(feature_dict)
-            else:
-                LOGGER.debug('Forecast hour {} not included in {}/{}/{} as '
-                             ' defined for variable {}. File will not be '
-                             'added to registry.'.format(fh, begin, end,
-                                                         interval,
-                                                         self.wx_variable))
+            if not self.is_valid_interval(fh, begin, end, interval):
+                feature_dict['register_status'] = False
+                LOGGER.debug('Forecast hour {} not included in {} as '
+                             'defined for layer {}. File will not be '
+                             'added to registry for this layer'
+                             .format(fh, forecast_hours, layer_name))
+
+            self.items.append(feature_dict)
 
         return True
-
-    def add_time_key(self):
-        """
-        Add time keys when applicable:
-            - model run default time
-            - model run extent
-            - forecast hour extent
-        and for observation:
-            - latest time step
-        """
-
-        for key, values in self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'].items():  # noqa
-
-            time_extent_key = '{}_time_extent'.format(key)
-            start, end, interval = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'][key]['forecast_hours'][self.model_run].split('/')  # noqa
-            start_time = self.date_ + timedelta(hours=int(start))
-            end_time = self.date_ + timedelta(hours=int(end))
-            start_time = start_time.strftime(DATE_FORMAT)
-            end_time = end_time.strftime(DATE_FORMAT)
-            time_extent_value = '{}/{}/{}'.format(start_time,
-                                                  end_time,
-                                                  interval)
-
-            default_model_key = '{}_default_model_run'.format(key)
-            stored_default_model_run = self.store.get_key(default_model_key)
-
-            model_run_extent_key = '{}_model_run_extent'.format(key)
-            retention_hours = self.file_dict[self.model]['model_run_retention_hours']  # noqa
-            interval_hours = self.file_dict[self.model]['model_run_interval_hours']  # noqa
-            default_model_run = self.date_.strftime(DATE_FORMAT)
-            run_start_time = (self.date_ - timedelta(hours=retention_hours)).strftime(DATE_FORMAT)  # noqa
-            run_interval = 'PT{}H'.format(interval_hours)
-            model_run_extent_value = '{}/{}/{}'.format(run_start_time, default_model_run, run_interval)  # noqa
-
-            if stored_default_model_run and datetime.strptime(stored_default_model_run, DATE_FORMAT) > self.date_:  # noqa
-                LOGGER.debug("New default model run value ({}) is older than the current value in store: {}. "  # noqa
-                             "Not updating time keys.".format(default_model_run, stored_default_model_run))  # noqa
-                continue
-
-            LOGGER.debug('Adding time keys in the store')
-
-            self.store.set_key(time_extent_key, time_extent_value)
-            self.store.set_key(default_model_key, default_model_run)
-            self.store.set_key(model_run_extent_key, model_run_extent_value)
 
     def __repr__(self):
         return '<ModelGemRegionalLayer> {}'.format(self.name)

--- a/geomet_data_registry/layer/model_hrdps_continental.py
+++ b/geomet_data_registry/layer/model_hrdps_continental.py
@@ -102,14 +102,14 @@ class ModelHrdpsContinentalLayer(BaseLayer):
                         forecast_hour_datetime.strftime(DATE_FORMAT))
         expected_count = self.file_dict[self.model]['variable'][self.wx_variable]['model_run'][self.model_run]['files_expected']  # noqa
 
-        for key, values in self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'].items():  # noqa
-            layer_name = key
+        self.geomet_layers = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers']  # noqa
+        for layer_name, layer_config in self.geomet_layers.items():  # noqa
             identifier = '{}-{}-{}'.format(layer_name, str_mr, str_fh)
 
-            begin, end, interval = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'][key]['forecast_hours'].split('/')  # noqa
-            interval_num = re.sub('[^0-9]', '', interval)
-
-            fh = file_pattern_info['fh']
+            forecast_hours = layer_config['forecast_hours']
+            begin, end, interval = [int(re.sub('[^0-9]', '', value))
+                                    for value in forecast_hours.split('/')]
+            fh = int(file_pattern_info['fh'])
 
             feature_dict = {
                 'layer_name': layer_name,
@@ -120,63 +120,26 @@ class ModelHrdpsContinentalLayer(BaseLayer):
                 'member': member,
                 'model': self.model,
                 'elevation': elevation,
-                'expected_count': expected_count
+                'expected_count': expected_count,
+                'forecast_hours': {
+                    'begin': begin,
+                    'end': end,
+                    'interval': forecast_hours.split('/')[2]
+                },
+                'layer_config': layer_config,
+                'register_status': True,
             }
 
-            if (int(fh) == 0 and int(interval_num) == 0) or \
-               (int(fh) in range(int(begin), int(end) + 1, int(interval_num))):
-                self.items.append(feature_dict)
-            else:
-                LOGGER.debug('Forecast hour {} not included in {}/{}/{} as '
-                             'defined for variable {}. File will not be added'
-                             ' to registry.'.format(fh, begin, end, interval,
-                                                    self.wx_variable))
+            if not self.is_valid_interval(fh, begin, end, interval):
+                feature_dict['register_status'] = False
+                LOGGER.debug('Forecast hour {} not included in {} as '
+                             'defined for layer {}. File will not be '
+                             'added to registry for this layer'
+                             .format(fh, forecast_hours, layer_name))
+
+            self.items.append(feature_dict)
 
         return True
-
-    def add_time_key(self):
-        """
-        Add time keys when applicable:
-            - model run default time
-            - model run extent
-            - forecast hour extent
-        and for observation:
-            - latest time step
-        """
-
-        for key, values in self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'].items():  # noqa
-
-            time_extent_key = '{}_time_extent'.format(key)
-            start, end, interval = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layers'][key]['forecast_hours'].split('/')  # noqa
-            start_time = self.date_ + timedelta(hours=int(start))
-            end_time = self.date_ + timedelta(hours=int(end))
-            start_time = start_time.strftime(DATE_FORMAT)
-            end_time = end_time.strftime(DATE_FORMAT)
-            time_extent_value = '{}/{}/{}'.format(start_time,
-                                                  end_time,
-                                                  interval)
-
-            default_model_key = '{}_default_model_run'.format(key)
-            stored_default_model_run = self.store.get_key(default_model_key)
-
-            model_run_extent_key = '{}_model_run_extent'.format(key)
-            retention_hours = self.file_dict[self.model]['model_run_retention_hours']  # noqa
-            interval_hours = self.file_dict[self.model]['model_run_interval_hours']  # noqa
-            default_model_run = self.date_.strftime(DATE_FORMAT)
-            run_start_time = (self.date_ - timedelta(hours=retention_hours)).strftime(DATE_FORMAT)  # noqa
-            run_interval = 'PT{}H'.format(interval_hours)
-            model_run_extent_value = '{}/{}/{}'.format(run_start_time, default_model_run, run_interval)  # noqa
-
-            if stored_default_model_run and datetime.strptime(stored_default_model_run, DATE_FORMAT) > self.date_:  # noqa
-                LOGGER.debug("New default model run value ({}) is older than the current value in store: {}. "  # noqa
-                             "Not updating time keys.".format(default_model_run, stored_default_model_run))  # noqa
-                continue
-
-            LOGGER.debug('Adding time keys in the store')
-
-            self.store.set_key(time_extent_key, time_extent_value)
-            self.store.set_key(default_model_key, default_model_run)
-            self.store.set_key(model_run_extent_key, model_run_extent_value)
 
     def __repr__(self):
         return '<ModelHrdpsContinentalLayer> {}'.format(self.name)

--- a/geomet_data_registry/layer/radar_1km.py
+++ b/geomet_data_registry/layer/radar_1km.py
@@ -102,7 +102,8 @@ class Radar1kmLayer(BaseLayer):
             'member': member,
             'model': self.model,
             'elevation': elevation,
-            'expected_count': None
+            'expected_count': None,
+            'register_status': True,
         }
         self.items.append(feature_dict)
 
@@ -110,12 +111,10 @@ class Radar1kmLayer(BaseLayer):
 
     def add_time_key(self):
         """
-        Add time keys when applicable:
-            - model run default time
-            - model run extent
-            - forecast hour extent
-        and for observation:
-            - latest time step
+        Adds default time and time extent datetime values to store for radar
+        layers. Overrides the add_time_key method of BaseLayer class due to
+        radar data's lack of forecast models.
+        :return: `bool` if successfully added a new radar time key
         """
 
         layer_name = self.file_dict[self.model]['variable'][self.wx_variable]['geomet_layer'] # noqa
@@ -139,6 +138,8 @@ class Radar1kmLayer(BaseLayer):
                                                                   self.date_))
             self.store.set_key(key_name, key_value)
             self.store.set_key(extent_key, extent_value)
+
+        return True
 
     def __repr__(self):
         return '<Radar1KM> {}'.format(self.name)

--- a/geomet_data_registry/layer/reps.py
+++ b/geomet_data_registry/layer/reps.py
@@ -46,7 +46,6 @@ class RepsLayer(BaseLayer):
         provider_def = {'name': 'reps'}
         self.type = None
         self.bands = None
-        self.layer_names = []
 
         BaseLayer.__init__(self, provider_def)
 
@@ -95,6 +94,7 @@ class RepsLayer(BaseLayer):
         self.model_run_list = list(runs.keys())
 
         weather_var = self.file_dict[self.model][self.type]['variable'][self.wx_variable]  # noqa
+        self.geomet_layers = weather_var['geomet_layers']
 
         time_format = '%Y%m%d%H'
         self.date_ = datetime.strptime(file_pattern_info['time_'], time_format)
@@ -121,82 +121,53 @@ class RepsLayer(BaseLayer):
 
             expected_count = self.file_dict[self.model][self.type]['variable'][self.wx_variable]['model_run'][self.model_run]['files_expected']  # noqa
 
-            for layer in weather_var['geomet_layers'].keys():
+            for layer, layer_config in self.geomet_layers.items():
                 if self.type == 'member':
                     member = self.bands[band]['member']
-                    layer_name = layer.format(str(self.bands[band]['member']).zfill(2)) # noqa
+                    layer_name = layer.format(str(self.bands[band]['member']).zfill(2))  # noqa
 
                 elif self.type == 'product':
                     member = None
-                    layer_name = layer.format(str(self.bands[band]['product']).zfill(2)) # noqa
+                    layer_name = layer.format(str(self.bands[band]['product']).zfill(2))  # noqa
 
                 identifier = '{}-{}-{}'.format(layer_name, str_mr, str_fh)
 
+                forecast_hours = layer_config['forecast_hours']
+                begin, end, interval = [int(re.sub('[^0-9]', '', value))
+                                        for value in
+                                        forecast_hours.split('/')]
+                fh = int(file_pattern_info['fh'])
+
                 feature_dict = {
                     'layer_name': layer_name,
+                    'layer_name_unformatted': layer,
                     'filepath': vrt,
                     'identifier': identifier,
-                    'reference_datetime': reference_datetime.strftime(DATE_FORMAT), # noqa
-                    'forecast_hour_datetime': forecast_hour_datetime.strftime(DATE_FORMAT), # noqa
+                    'reference_datetime': reference_datetime.strftime(DATE_FORMAT),  # noqa
+                    'forecast_hour_datetime': forecast_hour_datetime.strftime(DATE_FORMAT),  # noqa
                     'member': member,
                     'model': self.model,
                     'elevation': elevation,
-                    'expected_count': expected_count
+                    'expected_count': expected_count,
+                    'forecast_hours': {
+                        'begin': begin,
+                        'end': end,
+                        'interval': forecast_hours.split('/')[2]
+                    },
+                    'layer_config': layer_config,
+                    'register_status': True,
                 }
 
+                if not self.is_valid_interval(fh, begin, end, interval):
+                    feature_dict['register_status'] = False
+                    LOGGER.debug('Forecast hour {} not included in {} as '
+                                 'defined for layer {}. File will not be '
+                                 'added to registry for this layer'
+                                 .format(fh, forecast_hours, layer_name))
+
                 self.items.append(feature_dict)
-                self.layer_names.append(layer_name)
 
         return True
-
-    def add_time_key(self):
-        """
-        Add time keys when applicable:
-            - model run default time
-            - model run extent
-            - forecast hour extent
-        and for observation:
-            - latest time step
-        """
-
-        for key in self.layer_names:  # noqa
-
-            time_extent_key = '{}_time_extent'.format(key)
-
-            wx_info = self.file_dict[self.model][self.type]['variable'][self.wx_variable]  # noqa
-
-            for layer in wx_info['geomet_layers']:
-                if key.startswith(layer.format('')):
-                    start, end, interval = wx_info['geomet_layers'][layer]['forecast_hours'].split('/')  # noqa
-                    start_time = self.date_ + timedelta(hours=int(start))
-                    end_time = self.date_ + timedelta(hours=int(end))
-                    start_time = start_time.strftime(DATE_FORMAT)
-                    end_time = end_time.strftime(DATE_FORMAT)
-                    time_extent_value = '{}/{}/{}'.format(start_time,
-                                                          end_time,
-                                                          interval)
-
-            default_model_key = '{}_default_model_run'.format(key)
-            stored_default_model_run = self.store.get_key(default_model_key)
-
-            model_run_extent_key = '{}_model_run_extent'.format(key)
-            retention_hours = self.file_dict[self.model]['model_run_retention_hours']  # noqa
-            interval_hours = self.file_dict[self.model]['model_run_interval_hours']  # noqa
-            default_model_run = self.date_.strftime(DATE_FORMAT)
-            run_start_time = (self.date_ - timedelta(hours=retention_hours)).strftime(DATE_FORMAT)  # noqa
-            run_interval = 'PT{}H'.format(interval_hours)
-            model_run_extent_value = '{}/{}/{}'.format(run_start_time, default_model_run, run_interval)  # noqa
-
-            if stored_default_model_run and datetime.strptime(stored_default_model_run, DATE_FORMAT) > self.date_:  # noqa
-                LOGGER.debug("New default model run value ({}) is older than the current value in store: {}. "  # noqa
-                             "Not updating time keys.".format(default_model_run, stored_default_model_run))  # noqa
-                continue
-
-            LOGGER.debug('Adding time keys in the store')
-
-            self.store.set_key(time_extent_key, time_extent_value)
-            self.store.set_key(default_model_key, default_model_run)
-            self.store.set_key(model_run_extent_key, model_run_extent_value)
 
     def __repr__(self):
         return '<ModelREPSLayer> {}'.format(self.name)

--- a/geomet_data_registry/util.py
+++ b/geomet_data_registry/util.py
@@ -64,8 +64,9 @@ class VRTDataset:
         :returns: `str` of VRT.
         """
         if self.bands_order:
+            LOGGER.debug("Sorting filepaths against provided bands order.")
             self.filepaths = sorted(self.filepaths,
-                                    key=lambda fp:self.sort_band(fp))
+                                    key=lambda fp: self.sort_band(fp))
 
         for index, filepath in enumerate(self.filepaths, start=1):
             self.vrt_dataset.insert(-1, self.vrt_raster_band_template.format(
@@ -77,11 +78,10 @@ class VRTDataset:
         """
         :param filepath: `str` representation of filepath
         :returns: `int` of new filepath position in relation to
-        self.bands_order
+                  self.bands_order
         """
-        LOGGER.debug("Checking filepath against provided bands order.")
         filepath_postion = [idx for idx, value in enumerate(self.bands_order)
-                if value in filepath]
+                            if value in filepath]
         if len(filepath_postion) != 1:
             msg = "Band order could not be determined. Band order values do" \
                   " not match filepath or filepath matches several band " \
@@ -98,7 +98,7 @@ class VRTDataset:
         """
         formatted_vrt = ''
         for item in self.vrt_dataset:
-            formatted_vrt += dedent(re.sub('>\s+<', '><', item))
+            formatted_vrt += dedent(re.sub(r'>\s+<', '><', item))
 
         return formatted_vrt
 


### PR DESCRIPTION
This pull requests moves the `add_time_key()` method implemented by each model into the `BaseLayer` class in order to avoid some repetition in our code. The radar handler overwrites the method due to it's own particular characteristics (e.g. no model runs).

Tested these changes with complete model run data for all layer handlers that are affected.

Also included in this PR:

- Minor changes to `VRTDataset` util class (changed logger debug messages and add r to string literal for regex).
- Created `is_valid_interval()` static method in BaseLayer used by many model handlers to check if the incoming file is a valid time step as per the forecast_hours defined for that variable in its respective configuration file.
- Removal of some double quotes and other flake8 issues.
- Minor configuration changes to `model_giops.yml` to fix `files_expected` issues due to the `*Anal000.grib2` files for which we do not increase the count on.
- Make the looping through `geomet_layers` key of each weather variable a little more consistent between the various layer handlers (e.g `for layer_name, layer_config in self.geomet_layers.items():[...]`)