### PR TITLE
add UU layer handling for HRDPS, GIOPS, RDPS

### DIFF
--- a/conf/cgsl.yml
+++ b/conf/cgsl.yml
@@ -22,7 +22,7 @@ cgsl:
                 18Z:
                     files_expected: 48
             geomet_layers:
-                CGSL.ETA_UGRD:
+                CGSL.ETA_UU:
                     bands: 1,2
                     forecast_hours: 001/048/PT1H
         ocean:

--- a/conf/model_gem_regional.yml
+++ b/conf/model_gem_regional.yml
@@ -1,6 +1,9 @@
 model_gem_regional:
     model: RDPS
     filename_pattern: CMC_reg_{wx_variable}_ps10km_{YYYYMMDD_model_run}_P{forecast_hour}.grib2
+    dimensions:
+        x: 935
+        y: 824
     model_run_retention_hours: 48
     model_run_interval_hours: 6
     variable:
@@ -2616,6 +2619,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.50:
+                    dependencies:
+                        - RDPS.PRES_WSPD.50
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_50
+                - WIND_ISBL_50
         WDIR_ISBL_100:
             members: null
             elevation: 100mb
@@ -2635,6 +2649,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.100:
+                    dependencies:
+                        - RDPS.PRES_WSPD.100
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_100
+                - WIND_ISBL_100
         WDIR_ISBL_150:
             members: null
             elevation: 150mb
@@ -2654,6 +2679,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.150:
+                    dependencies:
+                        - RDPS.PRES_WSPD.150
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_150
+                - WIND_ISBL_150
         WDIR_ISBL_175:
             members: null
             elevation: 175mb
@@ -2673,6 +2709,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.175:
+                    dependencies:
+                        - RDPS.PRES_WSPD.175
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_175
+                - WIND_ISBL_175
         WDIR_ISBL_200:
             members: null
             elevation: 200mb
@@ -2692,6 +2739,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.200:
+                    dependencies:
+                        - RDPS.PRES_WSPD.200
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_200
+                - WIND_ISBL_200
         WDIR_ISBL_225:
             members: null
             elevation: 225mb
@@ -2711,6 +2769,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.225:
+                    dependencies:
+                        - RDPS.PRES_WSPD.225
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_225
+                - WIND_ISBL_225
         WDIR_ISBL_250:
             members: null
             elevation: 250mb
@@ -2730,6 +2799,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.250:
+                    dependencies:
+                        - RDPS.PRES_WSPD.250
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_250
+                - WIND_ISBL_250
         WDIR_ISBL_275:
             members: null
             elevation: 275mb
@@ -2749,6 +2829,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.275:
+                    dependencies:
+                        - RDPS.PRES_WSPD.275
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_275
+                - WIND_ISBL_275
         WDIR_ISBL_300:
             members: null
             elevation: 300mb
@@ -2768,6 +2859,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.300:
+                    dependencies:
+                        - RDPS.PRES_WSPD.300
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_300
+                - WIND_ISBL_300
         WDIR_ISBL_350:
             members: null
             elevation: 350mb
@@ -2787,6 +2889,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.350:
+                    dependencies:
+                        - RDPS.PRES_WSPD.350
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_350
+                - WIND_ISBL_350
         WDIR_ISBL_400:
             members: null
             elevation: 400mb
@@ -2806,6 +2919,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.400:
+                    dependencies:
+                        - RDPS.PRES_WSPD.400
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_400
+                - WIND_ISBL_400
         WDIR_ISBL_450:
             members: null
             elevation: 450mb
@@ -2825,6 +2949,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.450:
+                    dependencies:
+                        - RDPS.PRES_WSPD.450
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_450
+                - WIND_ISBL_450
         WDIR_ISBL_500:
             members: null
             elevation: 500mb
@@ -2844,6 +2979,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.500:
+                    dependencies:
+                        - RDPS.PRES_WSPD.500
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_500
+                - WIND_ISBL_500
         WDIR_ISBL_550:
             members: null
             elevation: 550mb
@@ -2863,6 +3009,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.550:
+                    dependencies:
+                        - RDPS.PRES_WSPD.550
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_550
+                - WIND_ISBL_550
         WDIR_ISBL_600:
             members: null
             elevation: 600mb
@@ -2882,6 +3039,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.600:
+                    dependencies:
+                        - RDPS.PRES_WSPD.600
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_600
+                - WIND_ISBL_600
         WDIR_ISBL_650:
             members: null
             elevation: 650mb
@@ -2901,6 +3069,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.650:
+                    dependencies:
+                        - RDPS.PRES_WSPD.650
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_650
+                - WIND_ISBL_650
         WDIR_ISBL_700:
             members: null
             elevation: 700mb
@@ -2920,6 +3099,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.700:
+                    dependencies:
+                        - RDPS.PRES_WSPD.700
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_700
+                - WIND_ISBL_700
         WDIR_ISBL_750:
             members: null
             elevation: 750mb
@@ -2939,6 +3129,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.750:
+                    dependencies:
+                        - RDPS.PRES_WSPD.750
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_750
+                - WIND_ISBL_750
         WDIR_ISBL_800:
             members: null
             elevation: 800mb
@@ -2958,6 +3159,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.800:
+                    dependencies:
+                        - RDPS.PRES_WSPD.800
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_800
+                - WIND_ISBL_800
         WDIR_ISBL_850:
             members: null
             elevation: 850mb
@@ -2977,6 +3189,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.850:
+                    dependencies:
+                        - RDPS.PRES_WSPD.850
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_850
+                - WIND_ISBL_850
         WDIR_ISBL_875:
             members: null
             elevation: 875mb
@@ -2996,6 +3219,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.875:
+                    dependencies:
+                        - RDPS.PRES_WSPD.875
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_875
+                - WIND_ISBL_875
         WDIR_ISBL_900:
             members: null
             elevation: 900mb
@@ -3015,6 +3249,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.900:
+                    dependencies:
+                        - RDPS.PRES_WSPD.900
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_900
+                - WIND_ISBL_900
         WDIR_ISBL_925:
             members: null
             elevation: 925mb
@@ -3034,6 +3279,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.925:
+                    dependencies:
+                        - RDPS.PRES_WSPD.925
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_925
+                - WIND_ISBL_925
         WDIR_ISBL_950:
             members: null
             elevation: 950mb
@@ -3053,6 +3309,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.950:
+                    dependencies:
+                        - RDPS.PRES_WSPD.950
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_950
+                - WIND_ISBL_950
         WDIR_ISBL_970:
             members: null
             elevation: 970mb
@@ -3072,6 +3339,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.970:
+                    dependencies:
+                        - RDPS.PRES_WSPD.970
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_970
+                - WIND_ISBL_970
         WDIR_ISBL_985:
             members: null
             elevation: 985mb
@@ -3091,6 +3369,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.985:
+                    dependencies:
+                        - RDPS.PRES_WSPD.985
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_985
+                - WIND_ISBL_985
         WDIR_ISBL_1000:
             members: null
             elevation: 1000mb
@@ -3110,6 +3399,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.1000:
+                    dependencies:
+                        - RDPS.PRES_WSPD.1000
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_1000
+                - WIND_ISBL_1000
         WDIR_ISBL_1015:
             members: null
             elevation: 1015mb
@@ -3129,6 +3429,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.1015:
+                    dependencies:
+                        - RDPS.PRES_WSPD.1015
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_1015
+                - WIND_ISBL_1015
         WDIR_TGL_10:
             members: null
             elevation: 10m
@@ -3148,6 +3459,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.ETA_UU:
+                    dependencies:
+                        - RDPS.ETA_WSPD
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_TGL_10
+                - WIND_TGL_10
         WIND_ISBL_50:
             members: null
             elevation: 50mb
@@ -3167,6 +3489,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.50:
+                    dependencies:
+                        - RDPS.PRES_WD.50
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_50
+                - WIND_ISBL_50
         WIND_ISBL_100:
             members: null
             elevation: 100mb
@@ -3186,6 +3519,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.100:
+                    dependencies:
+                        - RDPS.PRES_WD.100
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_100
+                - WIND_ISBL_100
         WIND_ISBL_150:
             members: null
             elevation: 150mb
@@ -3205,6 +3549,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.150:
+                    dependencies:
+                        - RDPS.PRES_WD.150
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_150
+                - WIND_ISBL_150
         WIND_ISBL_175:
             members: null
             elevation: 175mb
@@ -3224,6 +3579,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.175:
+                    dependencies:
+                        - RDPS.PRES_WD.175
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_175
+                - WIND_ISBL_175
         WIND_ISBL_200:
             members: null
             elevation: 200mb
@@ -3243,6 +3609,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.200:
+                    dependencies:
+                        - RDPS.PRES_WD.200
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_200
+                - WIND_ISBL_200
         WIND_ISBL_225:
             members: null
             elevation: 225mb
@@ -3262,6 +3639,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.225:
+                    dependencies:
+                        - RDPS.PRES_WD.225
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_225
+                - WIND_ISBL_225
         WIND_ISBL_250:
             members: null
             elevation: 250mb
@@ -3281,6 +3669,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.250:
+                    dependencies:
+                        - RDPS.PRES_WD.250
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_250
+                - WIND_ISBL_250
         WIND_ISBL_275:
             members: null
             elevation: 275mb
@@ -3300,6 +3699,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.275:
+                    dependencies:
+                        - RDPS.PRES_WD.275
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_275
+                - WIND_ISBL_275
         WIND_ISBL_300:
             members: null
             elevation: 300mb
@@ -3319,6 +3729,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.300:
+                    dependencies:
+                        - RDPS.PRES_WD.300
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_300
+                - WIND_ISBL_300
         WIND_ISBL_350:
             members: null
             elevation: 350mb
@@ -3338,6 +3759,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.350:
+                    dependencies:
+                        - RDPS.PRES_WD.350
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_350
+                - WIND_ISBL_350
         WIND_ISBL_400:
             members: null
             elevation: 400mb
@@ -3357,6 +3789,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.400:
+                    dependencies:
+                        - RDPS.PRES_WD.400
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_400
+                - WIND_ISBL_400
         WIND_ISBL_450:
             members: null
             elevation: 450mb
@@ -3376,6 +3819,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.450:
+                    dependencies:
+                        - RDPS.PRES_WD.450
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_450
+                - WIND_ISBL_450
         WIND_ISBL_500:
             members: null
             elevation: 500mb
@@ -3395,6 +3849,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.500:
+                    dependencies:
+                        - RDPS.PRES_WD.500
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_500
+                - WIND_ISBL_500
         WIND_ISBL_550:
             members: null
             elevation: 550mb
@@ -3414,6 +3879,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.550:
+                    dependencies:
+                        - RDPS.PRES_WD.550
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_550
+                - WIND_ISBL_550
         WIND_ISBL_600:
             members: null
             elevation: 600mb
@@ -3433,6 +3909,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.600:
+                    dependencies:
+                        - RDPS.PRES_WD.600
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_600
+                - WIND_ISBL_600
         WIND_ISBL_650:
             members: null
             elevation: 650mb
@@ -3452,6 +3939,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.650:
+                    dependencies:
+                        - RDPS.PRES_WD.650
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_650
+                - WIND_ISBL_650
         WIND_ISBL_700:
             members: null
             elevation: 700mb
@@ -3471,6 +3969,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.700:
+                    dependencies:
+                        - RDPS.PRES_WD.700
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_700
+                - WIND_ISBL_700
         WIND_ISBL_750:
             members: null
             elevation: 750mb
@@ -3490,6 +3999,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.750:
+                    dependencies:
+                        - RDPS.PRES_WD.750
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                    18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_750
+                - WIND_ISBL_750
         WIND_ISBL_800:
             members: null
             elevation: 800mb
@@ -3509,6 +4029,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.800:
+                    dependencies:
+                        - RDPS.PRES_WD.800
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_800
+                - WIND_ISBL_800
         WIND_ISBL_850:
             members: null
             elevation: 850mb
@@ -3528,6 +4059,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.850:
+                    dependencies:
+                        - RDPS.PRES_WD.850
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_850
+                - WIND_ISBL_850
         WIND_ISBL_875:
             members: null
             elevation: 875mb
@@ -3547,6 +4089,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.875:
+                    dependencies:
+                        - RDPS.PRES_WD.875
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_875
+                - WIND_ISBL_875
         WIND_ISBL_900:
             members: null
             elevation: 900mb
@@ -3566,6 +4119,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.900:
+                    dependencies:
+                        - RDPS.PRES_WD.900
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_900
+                - WIND_ISBL_900
         WIND_ISBL_925:
             members: null
             elevation: 925mb
@@ -3585,6 +4149,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.925:
+                    dependencies:
+                        - RDPS.PRES_WD.925
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_925
+                - WIND_ISBL_925
         WIND_ISBL_950:
             members: null
             elevation: 950mb
@@ -3604,6 +4179,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.950:
+                    dependencies:
+                        - RDPS.PRES_WD.950
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_950
+                - WIND_ISBL_950
         WIND_ISBL_970:
             members: null
             elevation: 970mb
@@ -3623,6 +4209,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.970:
+                    dependencies:
+                        - RDPS.PRES_WD.970
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_970
+                - WIND_ISBL_970
         WIND_ISBL_985:
             members: null
             elevation: 985mb
@@ -3642,6 +4239,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.985:
+                    dependencies:
+                        - RDPS.PRES_WD.985
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_985
+                - WIND_ISBL_985
         WIND_ISBL_1000:
             members: null
             elevation: 1000mb
@@ -3661,6 +4269,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.1000:
+                    dependencies:
+                        - RDPS.PRES_WD.1000
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_1000
+                - WIND_ISBL_1000
         WIND_ISBL_1015:
             members: null
             elevation: 1015mb
@@ -3680,6 +4299,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.PRES_UU.1015:
+                    dependencies:
+                        - RDPS.PRES_WD.1015
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_ISBL_1015
+                - WIND_ISBL_1015
         WIND_TGL_10:
             members: null
             elevation: 10m
@@ -3699,6 +4329,17 @@ model_gem_regional:
                         06Z: 000/054/PT1H
                         12Z: 000/048/PT1H
                         18Z: 000/054/PT1H
+                RDPS.ETA_UU:
+                    dependencies:
+                        - RDPS.ETA_WD
+                    forecast_hours:
+                        00Z: 000/048/PT1H
+                        06Z: 000/054/PT1H
+                        12Z: 000/048/PT1H
+                        18Z: 000/054/PT1H
+            bands_order:
+                - WDIR_TGL_10
+                - WIND_TGL_10
         WEAFR_SFC_0:
             members: null
             elevation: surface

--- a/conf/model_giops.yml
+++ b/conf/model_giops.yml
@@ -2,6 +2,9 @@ model_giops:
     model: GIOPS
     model_run_retention_hours: 120
     model_run_interval_hours: 12
+    dimensions:
+        x: 1800
+        y: 850
     filename_pattern: CMC_giops_{wx_variable}_{fileinfo:parse_fileinfo}_{YYYYMMDD_model_run}_{forecast_hour_prefix:l}{forecast_hour:n}.nc
     2D:
         variable:
@@ -126,6 +129,78 @@ model_giops:
                 geomet_layers:
                     OCEAN.GIOPS.2D_STGI:
                         forecast_hours: 003/240/PT3H
+            itmecrty:
+                members: null
+                elevation: surface
+                model_run:
+                    00Z:
+                        files_expected: 80
+                    12Z:
+                        files_expected: 80
+                geomet_layers:
+                    OCEAN.GIOPS.2D.UUY:
+                        forecast_hours: 003/240/PT3H
+                    OCEAN.GIOPS.2D.UUI:
+                        dependencies:
+                            - OCEAN.GIOPS.2D.UUX
+                        forecast_hours: 003/240/PT3H
+                bands_order:
+                    - itzocrtx
+                    - itmecrty
+            itzocrtx:
+                members: null
+                elevation: surface
+                model_run:
+                    00Z:
+                        files_expected: 80
+                    12Z:
+                        files_expected: 80
+                geomet_layers:
+                    OCEAN.GIOPS.2D.UUX:
+                        forecast_hours: 003/240/PT3H
+                    OCEAN.GIOPS.2D.UUI:
+                        dependencies:
+                            - OCEAN.GIOPS.2D.UUY
+                        forecast_hours: 003/240/PT3H
+                bands_order:
+                    - itzocrtx
+                    - itmecrty
+            vomecrty:
+                members: null
+                elevation: surface
+                model_run:
+                    00Z:
+                        files_expected: 80
+                    12Z:
+                        files_expected: 80
+                geomet_layers:
+                    OCEAN.GIOPS.2D.UU2W_Y:
+                        forecast_hours: 003/240/PT3H
+                    OCEAN.GIOPS.2D.UU2W:
+                        dependencies:
+                            - OCEAN.GIOPS.2D.UU2W_X
+                        forecast_hours: 003/240/PT3H
+                bands_order:
+                    - vozocrtx
+                    - vomecrty
+            vozocrtx:
+                members: null
+                elevation: surface
+                model_run:
+                    00Z:
+                        files_expected: 80
+                    12Z:
+                        files_expected: 80
+                geomet_layers:
+                    OCEAN.GIOPS.2D.UU2W_X:
+                        forecast_hours: 003/240/PT3H
+                    OCEAN.GIOPS.2D.UU2W:
+                        dependencies:
+                            - OCEAN.GIOPS.2D.UU2W_Y
+                        forecast_hours: 003/240/PT3H
+                bands_order:
+                    - vozocrtx
+                    - vomecrty
     3D:
         variable:
             vosaline:
@@ -450,3 +525,339 @@ model_giops:
                 geomet_layers:
                     OCEAN.GIOPS.3D_TM2_{}:
                         forecast_hours: 024/240/PT24H
+            vomecrty:
+                bands:
+                    1:
+                        product: '0000'
+                        elevation: surface
+                    2:
+                        product: '0002'
+                        elevation: -2m
+                    3:
+                        product: '0003'
+                        elevation: -3m
+                    4:
+                        product: '0004'
+                        elevation: -4m
+                    5:
+                        product: '0005'
+                        elevation: -5m
+                    6:
+                        product: '0006'
+                        elevation: -6m
+                    7:
+                        product: '0008'
+                        elevation: -8m
+                    8:
+                        product: '0010'
+                        elevation: -10m
+                    9:
+                        product: '0011'
+                        elevation: -11m
+                    10:
+                        product: '0013'
+                        elevation: -13m
+                    11:
+                        product: '0016'
+                        elevation: -16m
+                    12:
+                        product: '0018'
+                        elevation: -18m
+                    13:
+                        product: '0022'
+                        elevation: -22m
+                    14:
+                        product: '0025'
+                        elevation: -25m
+                    15:
+                        product: '0029'
+                        elevation: -29m
+                    16:
+                        product: '0034'
+                        elevation: -34m
+                    17:
+                        product: '0040'
+                        elevation: -40m
+                    18:
+                        product: '0047'
+                        elevation: -47m
+                    19:
+                        product: '0056'
+                        elevation: -56m
+                    20:
+                        product: '0066'
+                        elevation: -66m
+                    21:
+                        product: '0078'
+                        elevation: -78m
+                    22:
+                        product: '0092'
+                        elevation: -92m
+                    23:
+                        product: '0110'
+                        elevation: -110m
+                    24:
+                        product: '0131'
+                        elevation: -131m
+                    25:
+                        product: '0156'
+                        elevation: -156m
+                    26:
+                        product: '0186'
+                        elevation: -186m
+                    27:
+                        product: '0222'
+                        elevation: -222m
+                    28:
+                        product: '0266'
+                        elevation: -266m
+                    29:
+                        product: '0318'
+                        elevation: -318m
+                    30:
+                        product: '0380'
+                        elevation: -380m
+                    31:
+                        product: '0454'
+                        elevation: -454m
+                    32:
+                        product: '0541'
+                        elevation: -541m
+                    33:
+                        product: '0644'
+                        elevation: -644m
+                    34:
+                        product: '0763'
+                        elevation: -763m
+                    35:
+                        product: '0902'
+                        elevation: -902m
+                    36:
+                        product: '1062'
+                        elevation: -1062m
+                    37:
+                        product: '1245'
+                        elevation: -1245m
+                    38:
+                        product: '1452'
+                        elevation: -1452m
+                    39:
+                        product: '1684'
+                        elevation: -1684m
+                    40:
+                        product: '1942'
+                        elevation: -1942m
+                    41:
+                        product: '2225'
+                        elevation: -2225m
+                    42:
+                        product: '2533'
+                        elevation: -2533m
+                    43:
+                        product: '2866'
+                        elevation: -2866m
+                    44:
+                        product: '3221'
+                        elevation: -3221m
+                    45:
+                        product: '3597'
+                        elevation: -3597m
+                    46:
+                        product: '3992'
+                        elevation: -3992m
+                    47:
+                        product: '4405'
+                        elevation: -4405m
+                    48:
+                        product: '4833'
+                        elevation: -4833m
+                    49:
+                        product: '5275'
+                        elevation: -5275m
+                    50:
+                        product: '5728'
+                        elevation: -5728m
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 10
+                    12Z:
+                        files_expected: 10
+                geomet_layers:
+                    OCEAN.GIOPS.3D_UUW2_X_{}:
+                        forecast_hours: 024/240/PT24H
+                    OCEAN.GIOPS.3D_UU2W_{}:
+                        dependencies:
+                            - OCEAN.GIOPS.3D_UUW2_Y_{}
+                        forecast_hours: 024/240/PT24H
+                bands_order:
+                    - vozocrtx
+                    - vomecrty
+            vozocrtx:
+                bands:
+                    1:
+                        product: '0000'
+                        elevation: surface
+                    2:
+                        product: '0002'
+                        elevation: -2m
+                    3:
+                        product: '0003'
+                        elevation: -3m
+                    4:
+                        product: '0004'
+                        elevation: -4m
+                    5:
+                        product: '0005'
+                        elevation: -5m
+                    6:
+                        product: '0006'
+                        elevation: -6m
+                    7:
+                        product: '0008'
+                        elevation: -8m
+                    8:
+                        product: '0010'
+                        elevation: -10m
+                    9:
+                        product: '0011'
+                        elevation: -11m
+                    10:
+                        product: '0013'
+                        elevation: -13m
+                    11:
+                        product: '0016'
+                        elevation: -16m
+                    12:
+                        product: '0018'
+                        elevation: -18m
+                    13:
+                        product: '0022'
+                        elevation: -22m
+                    14:
+                        product: '0025'
+                        elevation: -25m
+                    15:
+                        product: '0029'
+                        elevation: -29m
+                    16:
+                        product: '0034'
+                        elevation: -34m
+                    17:
+                        product: '0040'
+                        elevation: -40m
+                    18:
+                        product: '0047'
+                        elevation: -47m
+                    19:
+                        product: '0056'
+                        elevation: -56m
+                    20:
+                        product: '0066'
+                        elevation: -66m
+                    21:
+                        product: '0078'
+                        elevation: -78m
+                    22:
+                        product: '0092'
+                        elevation: -92m
+                    23:
+                        product: '0110'
+                        elevation: -110m
+                    24:
+                        product: '0131'
+                        elevation: -131m
+                    25:
+                        product: '0156'
+                        elevation: -156m
+                    26:
+                        product: '0186'
+                        elevation: -186m
+                    27:
+                        product: '0222'
+                        elevation: -222m
+                    28:
+                        product: '0266'
+                        elevation: -266m
+                    29:
+                        product: '0318'
+                        elevation: -318m
+                    30:
+                        product: '0380'
+                        elevation: -380m
+                    31:
+                        product: '0454'
+                        elevation: -454m
+                    32:
+                        product: '0541'
+                        elevation: -541m
+                    33:
+                        product: '0644'
+                        elevation: -644m
+                    34:
+                        product: '0763'
+                        elevation: -763m
+                    35:
+                        product: '0902'
+                        elevation: -902m
+                    36:
+                        product: '1062'
+                        elevation: -1062m
+                    37:
+                        product: '1245'
+                        elevation: -1245m
+                    38:
+                        product: '1452'
+                        elevation: -1452m
+                    39:
+                        product: '1684'
+                        elevation: -1684m
+                    40:
+                        product: '1942'
+                        elevation: -1942m
+                    41:
+                        product: '2225'
+                        elevation: -2225m
+                    42:
+                        product: '2533'
+                        elevation: -2533m
+                    43:
+                        product: '2866'
+                        elevation: -2866m
+                    44:
+                        product: '3221'
+                        elevation: -3221m
+                    45:
+                        product: '3597'
+                        elevation: -3597m
+                    46:
+                        product: '3992'
+                        elevation: -3992m
+                    47:
+                        product: '4405'
+                        elevation: -4405m
+                    48:
+                        product: '4833'
+                        elevation: -4833m
+                    49:
+                        product: '5275'
+                        elevation: -5275m
+                    50:
+                        product: '5728'
+                        elevation: -5728m
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 10
+                    12Z:
+                        files_expected: 10
+                geomet_layers:
+                    OCEAN.GIOPS.3D_UUW2_Y_{}:
+                        forecast_hours: 024/240/PT24H
+                    OCEAN.GIOPS.3D_UU2W_{}:
+                        dependencies:
+                            - OCEAN.GIOPS.3D_UUW2_X_{}
+                        forecast_hours: 024/240/PT24H
+                bands_order:
+                    - vozocrtx
+                    - vomecrty

--- a/conf/model_hrdps_continental.yml
+++ b/conf/model_hrdps_continental.yml
@@ -1,6 +1,9 @@
 model_hrdps_continental:
     model: HRDPS
     filename_pattern: CMC_hrdps_continental_{wx_variable}_ps2.5km_{YYYYMMDD_model_run}_P{forecast_hour}-00.grib2
+    dimensions:
+        x: 2576
+        y: 1456
     model_run_retention_hours: 48
     model_run_interval_hours: 6
     variable:
@@ -2456,8 +2459,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.50:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.50:
+                HRDPS.CONTINENTAL.PRES_UU.50:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.50
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0050
+                - WIND_ISBL_0050
         WDIR_ISBL_0100:
             members: null
             elevation: 100mb
@@ -2473,8 +2481,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.100:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.100:
+                HRDPS.CONTINENTAL.PRES_UU.100:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.100
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0100
+                - WIND_ISBL_0100
         WDIR_ISBL_0150:
             members: null
             elevation: 150mb
@@ -2490,8 +2503,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.150:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.150:
+                HRDPS.CONTINENTAL.PRES_UU.150:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.150
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0150
+                - WIND_ISBL_0150
         WDIR_ISBL_0175:
             members: null
             elevation: 175mb
@@ -2507,8 +2525,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.175:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.175:
+                HRDPS.CONTINENTAL.PRES_UU.175:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.175
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0175
+                - WIND_ISBL_0175
         WDIR_ISBL_0200:
             members: null
             elevation: 200mb
@@ -2524,8 +2547,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.200:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.200:
+                HRDPS.CONTINENTAL.PRES_UU.200:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.200
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0200
+                - WIND_ISBL_0200
         WDIR_ISBL_0225:
             members: null
             elevation: 225mb
@@ -2541,8 +2569,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.225:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.225:
+                HRDPS.CONTINENTAL.PRES_UU.225:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.225
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0225
+                - WIND_ISBL_0225
         WDIR_ISBL_0250:
             members: null
             elevation: 250mb
@@ -2558,8 +2591,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.250:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.250:
+                HRDPS.CONTINENTAL.PRES_UU.250:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.250
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0250
+                - WIND_ISBL_0250
         WDIR_ISBL_0275:
             members: null
             elevation: 275mb
@@ -2575,8 +2613,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.275:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.275:
+                HRDPS.CONTINENTAL.PRES_UU.275:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.275
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0275
+                - WIND_ISBL_0275
         WDIR_ISBL_0300:
             members: null
             elevation: 300mb
@@ -2592,8 +2635,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.300:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.300:
+                HRDPS.CONTINENTAL.PRES_UU.300:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.300
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0300
+                - WIND_ISBL_0300
         WDIR_ISBL_0350:
             members: null
             elevation: 350mb
@@ -2609,8 +2657,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.350:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.350:
+                HRDPS.CONTINENTAL.PRES_UU.350:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.350
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0350
+                - WIND_ISBL_0350
         WDIR_ISBL_0400:
             members: null
             elevation: 400mb
@@ -2626,8 +2679,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.400:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.400:
+                HRDPS.CONTINENTAL.PRES_UU.400:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.400
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0400
+                - WIND_ISBL_0400
         WDIR_ISBL_0450:
             members: null
             elevation: 450mb
@@ -2643,8 +2701,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.450:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.450:
+                HRDPS.CONTINENTAL.PRES_UU.450:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.450
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0450
+                - WIND_ISBL_0450
         WDIR_ISBL_0500:
             members: null
             elevation: 500mb
@@ -2660,8 +2723,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.500:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.500:
+                HRDPS.CONTINENTAL.PRES_UU.500:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.500
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0500
+                - WIND_ISBL_0500
         WDIR_ISBL_0550:
             members: null
             elevation: 550mb
@@ -2677,8 +2745,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.550:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.550:
+                HRDPS.CONTINENTAL.PRES_UU.550:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.550
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0550
+                - WIND_ISBL_0550
         WDIR_ISBL_0600:
             members: null
             elevation: 600mb
@@ -2694,8 +2767,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.600:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.600:
+                HRDPS.CONTINENTAL.PRES_UU.600:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.600
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0600
+                - WIND_ISBL_0600
         WDIR_ISBL_0650:
             members: null
             elevation: 650mb
@@ -2711,8 +2789,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.650:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.650:
+                HRDPS.CONTINENTAL.PRES_UU.650:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.650
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0650
+                - WIND_ISBL_0650
         WDIR_ISBL_0700:
             members: null
             elevation: 700mb
@@ -2728,8 +2811,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.700:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.700:
+                HRDPS.CONTINENTAL.PRES_UU.700:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.700
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0700
+                - WIND_ISBL_0700
         WDIR_ISBL_0750:
             members: null
             elevation: 750mb
@@ -2745,8 +2833,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.750:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.750:
+                HRDPS.CONTINENTAL.PRES_UU.750:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.750
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0750
+                - WIND_ISBL_0750
         WDIR_ISBL_0800:
             members: null
             elevation: 800mb
@@ -2762,8 +2855,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.800:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.800:
+                HRDPS.CONTINENTAL.PRES_UU.800:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.800
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0800
+                - WIND_ISBL_0800
         WDIR_ISBL_0850:
             members: null
             elevation: 850mb
@@ -2779,8 +2877,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.850:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.850:
+                HRDPS.CONTINENTAL.PRES_UU.850:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.850
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0850
+                - WIND_ISBL_0850
         WDIR_ISBL_0875:
             members: null
             elevation: 875mb
@@ -2796,8 +2899,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.875:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.875:
+                HRDPS.CONTINENTAL.PRES_UU.875:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.875
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0875
+                - WIND_ISBL_0875
         WDIR_ISBL_0900:
             members: null
             elevation: 900mb
@@ -2813,8 +2921,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.900:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.900:
+                HRDPS.CONTINENTAL.PRES_UU.900:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.900
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0900
+                - WIND_ISBL_0900
         WDIR_ISBL_0925:
             members: null
             elevation: 925mb
@@ -2830,8 +2943,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.925:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.925:
+                HRDPS.CONTINENTAL.PRES_UU.925:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.925
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0925
+                - WIND_ISBL_0925
         WDIR_ISBL_0950:
             members: null
             elevation: 950mb
@@ -2847,8 +2965,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.950:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.950:
+                HRDPS.CONTINENTAL.PRES_UU.950:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.950
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0950
+                - WIND_ISBL_0950
         WDIR_ISBL_0970:
             members: null
             elevation: 970mb
@@ -2864,8 +2987,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.970:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.970:
+                HRDPS.CONTINENTAL.PRES_UU.970:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.970
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0970
+                - WIND_ISBL_0970
         WDIR_ISBL_0985:
             members: null
             elevation: 985mb
@@ -2881,8 +3009,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.985:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.985:
+                HRDPS.CONTINENTAL.PRES_UU.985:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.985
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0985
+                - WIND_ISBL_0985
         WDIR_ISBL_1000:
             members: null
             elevation: 1000mb
@@ -2898,8 +3031,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.1000:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.1000:
+                HRDPS.CONTINENTAL.PRES_UU.1000:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.1000
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_1000
+                - WIND_ISBL_1000
         WDIR_ISBL_1015:
             members: null
             elevation: 1015mb
@@ -2915,8 +3053,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.1015:
                     forecast_hours: 000/048/PT1H
-                HRDPS.CONTINENTAL.PRES_WSPD.1015:
+                HRDPS.CONTINENTAL.PRES_UU.1015:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WSPD.1015
                     forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_1015
+                - WIND_ISBL_1015
         WDIR_TGL_10:
             members: null
             elevation: 10m
@@ -2932,6 +3075,629 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL_WD:
                     forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL_UU:
+                    dependencies:
+                        - HRDPS.CONTINENTAL_WSPD
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_TGL_10
+                - WIND_TGL_10
+        WIND_ISBL_0050:
+            members: null
+            elevation: 50mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.50:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.50:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.50
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0050
+                - WIND_ISBL_0050
+        WIND_ISBL_0100:
+            members: null
+            elevation: 100mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.100:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.100:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.100
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0100
+                - WIND_ISBL_0100
+        WIND_ISBL_0150:
+            members: null
+            elevation: 150mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.150:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.150:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.150
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0150
+                - WIND_ISBL_0150
+        WIND_ISBL_0175:
+            members: null
+            elevation: 175mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.175:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.175:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.175
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0175
+                - WIND_ISBL_0175
+        WIND_ISBL_0200:
+            members: null
+            elevation: 200mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.200:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.200:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.200
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0200
+                - WIND_ISBL_0200
+        WIND_ISBL_0225:
+            members: null
+            elevation: 225mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.225:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.225:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.225
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0225
+                - WIND_ISBL_0225
+        WIND_ISBL_0250:
+            members: null
+            elevation: 250mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.250:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.250:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.250
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0250
+                - WIND_ISBL_0250
+        WIND_ISBL_0275:
+            members: null
+            elevation: 275mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.275:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.275:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.275
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0275
+                - WIND_ISBL_0275
+        WIND_ISBL_0300:
+            members: null
+            elevation: 300mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.300:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.300:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.300
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0300
+                - WIND_ISBL_0300
+        WIND_ISBL_0350:
+            members: null
+            elevation: 350mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.350:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.350:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.350
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0350
+                - WIND_ISBL_0350
+        WIND_ISBL_0400:
+            members: null
+            elevation: 400mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.400:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.400:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.400
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0400
+                - WIND_ISBL_0400
+        WIND_ISBL_0450:
+            members: null
+            elevation: 450mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.450:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.450:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.450
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0450
+                - WIND_ISBL_0450
+        WIND_ISBL_0500:
+            members: null
+            elevation: 500mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.500:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.500:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.500
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0500
+                - WIND_ISBL_0500
+        WIND_ISBL_0550:
+            members: null
+            elevation: 550mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.550:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.550:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.550
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0550
+                - WIND_ISBL_0550
+        WIND_ISBL_0600:
+            members: null
+            elevation: 600mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.600:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.600:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.600
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0600
+                - WIND_ISBL_0600
+        WIND_ISBL_0650:
+            members: null
+            elevation: 650mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.650:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.650:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.650
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0650
+                - WIND_ISBL_0650
+        WIND_ISBL_0700:
+            members: null
+            elevation: 700mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.700:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.700:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.700
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0700
+                - WIND_ISBL_0700
+        WIND_ISBL_0750:
+            members: null
+            elevation: 750mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.750:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.750:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.750
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0750
+                - WIND_ISBL_0750
+        WIND_ISBL_0800:
+            members: null
+            elevation: 800mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.800:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.800:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.800
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0800
+                - WIND_ISBL_0800
+        WIND_ISBL_0850:
+            members: null
+            elevation: 850mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.850:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.850:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.850
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0850
+                - WIND_ISBL_0850
+        WIND_ISBL_0875:
+            members: null
+            elevation: 875mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.875:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.875:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.875
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0875
+                - WIND_ISBL_0875
+        WIND_ISBL_0900:
+            members: null
+            elevation: 900mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.900:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.900:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.900
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0900
+                - WIND_ISBL_0900
+        WIND_ISBL_0925:
+            members: null
+            elevation: 925mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.925:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.925:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.925
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0925
+                - WIND_ISBL_0925
+        WIND_ISBL_0950:
+            members: null
+            elevation: 950mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.950:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.950:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.950
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0950
+                - WIND_ISBL_0950
+        WIND_ISBL_0970:
+            members: null
+            elevation: 970mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.970:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.970:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.970
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0970
+                - WIND_ISBL_0970
+        WIND_ISBL_0985:
+            members: null
+            elevation: 985mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.985:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.985:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.985
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_0985
+                - WIND_ISBL_0985
+        WIND_ISBL_1000:
+            members: null
+            elevation: 1000mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.1000:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.1000:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.1000
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_1000
+                - WIND_ISBL_1000
+        WIND_ISBL_1015:
+            members: null
+            elevation: 1015mb
+            model_run:
+                00Z:
+                    files_expected: 49
+                06Z:
+                    files_expected: 49
+                12Z:
+                    files_expected: 49
+                18Z:
+                    files_expected: 49
+            geomet_layers:
+                HRDPS.CONTINENTAL.PRES_WSPD.1015:
+                    forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL.PRES_UU.1015:
+                    dependencies:
+                        - HRDPS.CONTINENTAL.PRES_WD.1015
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_ISBL_1015
+                - WIND_ISBL_1015
         WEAFR_SFC_0:
             members: null
             elevation: surface
@@ -2992,6 +3758,13 @@ model_hrdps_continental:
             geomet_layers:
                 HRDPS.CONTINENTAL_WSPD:
                     forecast_hours: 000/048/PT1H
+                HRDPS.CONTINENTAL_UU:
+                    dependencies:
+                        - HRDPS.CONTINENTAL_WD
+                    forecast_hours: 000/048/PT1H
+            bands_order:
+                - WDIR_TGL_10
+                - WIND_TGL_10
 
 
             

--- a/geomet_data_registry/layer/model_gem_regional.py
+++ b/geomet_data_registry/layer/model_gem_regional.py
@@ -81,6 +81,8 @@ class ModelGemRegionalLayer(BaseLayer):
             LOGGER.warning(msg)
             return False
 
+        self.dimensions = self.file_dict[self.model]['dimensions']
+
         runs = self.file_dict[self.model]['variable'][self.wx_variable]['model_run']  # noqa
         self.model_run_list = list(runs.keys())
 
@@ -130,6 +132,26 @@ class ModelGemRegionalLayer(BaseLayer):
                 'layer_config': layer_config,
                 'register_status': True,
             }
+
+            if 'dependencies' in layer_config:
+                dependencies_found = self.check_layer_dependencies(
+                    layer_config['dependencies'],
+                    str_mr,
+                    str_fh)
+                if dependencies_found:
+                    bands_order = (self.file_dict[self.model]
+                                   ['variable']
+                                   [self.wx_variable].get('bands_order'))
+                    (feature_dict['filepath'],
+                     feature_dict['weather_variable']) = (
+                        self.configure_layer_with_dependencies(
+                            dependencies_found,
+                            self.dimensions,
+                            bands_order))
+                else:
+                    feature_dict['register_status'] = False
+                    self.items.append(feature_dict)
+                    continue
 
             if not self.is_valid_interval(fh, begin, end, interval):
                 feature_dict['register_status'] = False

--- a/geomet_data_registry/layer/model_hrdps_continental.py
+++ b/geomet_data_registry/layer/model_hrdps_continental.py
@@ -80,6 +80,8 @@ class ModelHrdpsContinentalLayer(BaseLayer):
             LOGGER.warning(msg)
             return False
 
+        self.dimensions = self.file_dict[self.model]['dimensions']
+
         runs = self.file_dict[self.model]['variable'][self.wx_variable]['model_run']  # noqa
         self.model_run_list = list(runs.keys())
 
@@ -129,6 +131,26 @@ class ModelHrdpsContinentalLayer(BaseLayer):
                 'layer_config': layer_config,
                 'register_status': True,
             }
+
+            if 'dependencies' in layer_config:
+                dependencies_found = self.check_layer_dependencies(
+                    layer_config['dependencies'],
+                    str_mr,
+                    str_fh)
+                if dependencies_found:
+                    bands_order = (self.file_dict[self.model]
+                                   ['variable']
+                                   [self.wx_variable].get('bands_order'))
+                    (feature_dict['filepath'],
+                     feature_dict['weather_variable']) = (
+                        self.configure_layer_with_dependencies(
+                            dependencies_found,
+                            self.dimensions,
+                            bands_order))
+                else:
+                    feature_dict['register_status'] = False
+                    self.items.append(feature_dict)
+                    continue
 
             if not self.is_valid_interval(fh, begin, end, interval):
                 feature_dict['register_status'] = False


### PR DESCRIPTION
Add UU layer handling in HRDPS, GIOPS and RDPS layer handlers and added these new layers to the yaml configuration file for each model.

From what I can tell, we now have all UU layers in GeoMet 2 being served via GeoMet 3.

I have tested each model with complete model runs for the impacted variables.