### PR TITLE
add URL property to workflow

### DIFF
--- a/geomet_data_registry/event.py
+++ b/geomet_data_registry/event.py
@@ -34,14 +34,13 @@ class Event:
         :returns: `bool` of dispatch result
         """
 
-        from urllib.parse import urlunparse
-
         from geomet_data_registry import env
         from geomet_data_registry.log import setup_logger
 
         setup_logger(env.LOGGING_LOGLEVEL, env.LOGGING_LOGFILE)
 
         try:
+            from urllib.parse import urlunparse
             from geomet_data_registry.handler.core import CoreHandler
 
             filepath = parent.msg.local_file

--- a/geomet_data_registry/event.py
+++ b/geomet_data_registry/event.py
@@ -34,6 +34,8 @@ class Event:
         :returns: `bool` of dispatch result
         """
 
+        from urllib.parse import urlunparse
+
         from geomet_data_registry import env
         from geomet_data_registry.log import setup_logger
 
@@ -44,7 +46,9 @@ class Event:
 
             filepath = parent.msg.local_file
             parent.logger.debug('Filepath: {}'.format(filepath))
-            handler = CoreHandler(filepath)
+            url = urlunparse(parent.msg.url)
+            parent.logger.debug('URL: {}'.format(url))
+            handler = CoreHandler(filepath, url)
             result = handler.handle()
             parent.logger.debug('Result: {}'.format(result))
             return True

--- a/geomet_data_registry/handler/base.py
+++ b/geomet_data_registry/handler/base.py
@@ -25,15 +25,18 @@ LOGGER = logging.getLogger(__name__)
 class BaseHandler:
     """base handler"""
 
-    def __init__(self, filepath):
+    def __init__(self, filepath, url=None):
         """
         initializer
 
         :param filepath: path to file
+        :param url: fully qualified URL of file
         """
 
         self.filepath = filepath
+        self.url = url
         LOGGER.debug('Filepath: {}'.format(self.filepath))
+        LOGGER.debug('URL: {}'.format(self.url))
 
     def handle(self):
         """handle incoming file"""

--- a/geomet_data_registry/handler/core.py
+++ b/geomet_data_registry/handler/core.py
@@ -45,18 +45,19 @@ DATASET_HANDLERS = {
 class CoreHandler(BaseHandler):
     """base handler"""
 
-    def __init__(self, filepath):
+    def __init__(self, filepath, url=None):
         """
         initializer
 
         :param filepath: path to file
+        :param url: fully qualified URL of file
 
         :returns: `geomet_data_registry.handler.core.CoreHandler`
         """
 
         self.layer_plugin = None
 
-        BaseHandler.__init__(self, filepath)
+        super().__init__(self, filepath, url)
 
     def handle(self):
         """
@@ -80,7 +81,7 @@ class CoreHandler(BaseHandler):
             raise RuntimeError(msg)
 
         LOGGER.debug('Identifying file')
-        identify_status = self.layer_plugin.identify(self.filepath)
+        identify_status = self.layer_plugin.identify(self.filepath, self.url)
 
         if identify_status:
             self.layer_plugin.identify_datetime = get_today_and_now()
@@ -91,4 +92,4 @@ class CoreHandler(BaseHandler):
         return True
 
     def __repr__(self):
-        return '<CoreHandler> {}'.format(self.filepath)
+        return '<CoreHandler> {}'.format(self.url)

--- a/geomet_data_registry/layer/base.py
+++ b/geomet_data_registry/layer/base.py
@@ -50,6 +50,7 @@ class BaseLayer:
         self.identify_datetime = None
         self.register_datetime = None
         self.filepath = None
+        self.url = None
         self.dimensions = None
         self.model = None
         self.model_run = None
@@ -63,16 +64,18 @@ class BaseLayer:
         self.store = load_plugin('store', STORE_PROVIDER_DEF)
         self.tileindex = load_plugin('tileindex', TILEINDEX_PROVIDER_DEF)
 
-    def identify(self, filepath):
+    def identify(self, filepath, url=None):
         """
         Identifies a file of the layer
 
         :param filepath: filepath on disk
+        :param url: fully qualified URL of file
 
         :returns: `bool` of file properties
         """
 
         self.filepath = filepath
+        self.url = url
         self.file_creation_datetime = datetime.fromtimestamp(
             os.path.getmtime(filepath)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
@@ -127,6 +130,7 @@ class BaseLayer:
                  'identifier': item['identifier'],
                  'layer': item['layer_name'],
                  'filepath': item['filepath'],
+                 'url': item['url'],
                  'elevation': item['elevation'],
                  'member': item['member'],
                  'model': item['model'],

--- a/geomet_data_registry/layer/base.py
+++ b/geomet_data_registry/layer/base.py
@@ -130,7 +130,7 @@ class BaseLayer:
                  'identifier': item['identifier'],
                  'layer': item['layer_name'],
                  'filepath': item['filepath'],
-                 'url': item['url'],
+                 'url': self.url,
                  'elevation': item['elevation'],
                  'member': item['member'],
                  'model': item['model'],

--- a/geomet_data_registry/layer/cansips.py
+++ b/geomet_data_registry/layer/cansips.py
@@ -45,18 +45,19 @@ class CansipsLayer(BaseLayer):
 
         provider_def = {'name': 'cansips'}
 
-        BaseLayer.__init__(self, provider_def)
+        super().__init__(self, provider_def)
 
-    def identify(self, filepath):
+    def identify(self, filepath, url=None):
         """
         Identifies a file of the layer
 
         :param filepath: filepath from AMQP
+        :param url: fully qualified URL of file
 
         :returns: `list` of file properties
         """
 
-        super().identify(filepath)
+        super().identify(filepath, url)
 
         self.model = 'cansips'
 
@@ -129,6 +130,7 @@ class CansipsLayer(BaseLayer):
                 feature_dict = {
                     'layer_name': layer_name,
                     'filepath': vrt,
+                    'url': url,
                     'identifier': identifier,
                     'reference_datetime': reference_datetime.strftime(
                         DATE_FORMAT),

--- a/geomet_data_registry/layer/cansips.py
+++ b/geomet_data_registry/layer/cansips.py
@@ -130,7 +130,6 @@ class CansipsLayer(BaseLayer):
                 feature_dict = {
                     'layer_name': layer_name,
                     'filepath': vrt,
-                    'url': url,
                     'identifier': identifier,
                     'reference_datetime': reference_datetime.strftime(
                         DATE_FORMAT),

--- a/geomet_data_registry/layer/cgsl.py
+++ b/geomet_data_registry/layer/cgsl.py
@@ -44,18 +44,19 @@ class CgslLayer(BaseLayer):
 
         provider_def = {'name': 'cgsl'}
 
-        BaseLayer.__init__(self, provider_def)
+        super().__init__(self, provider_def)
 
-    def identify(self, filepath):
+    def identify(self, filepath, url=None):
         """
         Identifies a file of the layer
 
         :param filepath: filepath from AMQP
+        :param url: fully qualified URL of file
 
         :returns: `list` of file properties
         """
 
-        super().identify(filepath)
+        super().identify(filepath, url)
 
         self.model = 'cgsl'
 

--- a/geomet_data_registry/layer/gdwps.py
+++ b/geomet_data_registry/layer/gdwps.py
@@ -44,18 +44,19 @@ class GdwpsLayer(BaseLayer):
 
         provider_def = {'name': 'gdwps'}
 
-        BaseLayer.__init__(self, provider_def)
+        super().__init__(self, provider_def)
 
-    def identify(self, filepath):
+    def identify(self, filepath, url=None):
         """
         Identifies a file of the layer
 
         :param filepath: filepath from AMQP
+        :param url: fully qualified URL of file
 
         :returns: `list` of file properties
         """
 
-        super().identify(filepath)
+        super().identify(filepath, url)
 
         self.model = 'gdwps'
 
@@ -121,7 +122,7 @@ class GdwpsLayer(BaseLayer):
 
             feature_dict = {
                 'layer_name': layer_name,
-                'filepath': filepath,
+                'filepath': self.filepath,
                 'identifier': identifier,
                 'reference_datetime': reference_datetime.strftime(DATE_FORMAT),
                 'forecast_hour_datetime': forecast_hour_datetime.strftime(

--- a/geomet_data_registry/layer/geps.py
+++ b/geomet_data_registry/layer/geps.py
@@ -150,7 +150,6 @@ class GepsLayer(BaseLayer):
                     'layer_name': layer_name,
                     'layer_name_unformatted': layer,
                     'filepath': vrt,
-                    'url': url,
                     'identifier': identifier,
                     'reference_datetime': reference_datetime.strftime(
                         DATE_FORMAT),

--- a/geomet_data_registry/layer/geps.py
+++ b/geomet_data_registry/layer/geps.py
@@ -47,18 +47,19 @@ class GepsLayer(BaseLayer):
         self.type = None
         self.bands = None
 
-        BaseLayer.__init__(self, provider_def)
+        super().__init__(self, provider_def)
 
-    def identify(self, filepath):
+    def identify(self, filepath, url=None):
         """
         Identifies a file of the layer
 
         :param filepath: filepath from AMQP
+        :param url: fully qualified URL of file
 
         :returns: `list` of file properties
         """
 
-        super().identify(filepath)
+        super().identify(filepath, url)
 
         self.model = 'geps'
 
@@ -149,6 +150,7 @@ class GepsLayer(BaseLayer):
                     'layer_name': layer_name,
                     'layer_name_unformatted': layer,
                     'filepath': vrt,
+                    'url': url,
                     'identifier': identifier,
                     'reference_datetime': reference_datetime.strftime(
                         DATE_FORMAT),

--- a/geomet_data_registry/layer/hrdpa.py
+++ b/geomet_data_registry/layer/hrdpa.py
@@ -44,18 +44,19 @@ class HrdpaLayer(BaseLayer):
 
         provider_def = {'name': 'hrdpa'}
 
-        BaseLayer.__init__(self, provider_def)
+        super().__init__(self, provider_def)
 
-    def identify(self, filepath):
+    def identify(self, filepath, url=None):
         """
         Identifies a file of the layer
 
         :param filepath: filepath from AMQP
+        :param url: fully qualified URL of file
 
         :returns: `list` of file properties
         """
 
-        super().identify(filepath)
+        super().identify(filepath, url)
 
         self.model = 'hrdpa'
 
@@ -114,7 +115,7 @@ class HrdpaLayer(BaseLayer):
 
             feature_dict = {
                 'layer_name': layer_name,
-                'filepath': filepath,
+                'filepath': self.filepath,
                 'identifier': identifier,
                 'reference_datetime': None,
                 'forecast_hour_datetime': self.date_.strftime(DATE_FORMAT),

--- a/geomet_data_registry/layer/model_gem_global.py
+++ b/geomet_data_registry/layer/model_gem_global.py
@@ -44,18 +44,19 @@ class ModelGemGlobalLayer(BaseLayer):
 
         provider_def = {'name': 'model_gem_global'}
 
-        BaseLayer.__init__(self, provider_def)
+        super().__init__(self, provider_def)
 
-    def identify(self, filepath):
+    def identify(self, filepath, url=None):
         """
         Identifies a file of the layer
 
         :param filepath: filepath from AMQP
+        :param url: fully qualified URL of file
 
         :returns: `list` of file properties
         """
 
-        super().identify(filepath)
+        super().identify(filepath, url)
 
         self.model = 'model_gem_global'
 
@@ -121,7 +122,7 @@ class ModelGemGlobalLayer(BaseLayer):
 
             feature_dict = {
                 'layer_name': layer_name,
-                'filepath': filepath,
+                'filepath': self.filepath,
                 'identifier': identifier,
                 'reference_datetime': reference_datetime.strftime(
                     DATE_FORMAT),

--- a/geomet_data_registry/layer/model_gem_regional.py
+++ b/geomet_data_registry/layer/model_gem_regional.py
@@ -44,18 +44,19 @@ class ModelGemRegionalLayer(BaseLayer):
 
         provider_def = {'name': 'model_gem_regional'}
 
-        BaseLayer.__init__(self, provider_def)
+        super().__init__(self, provider_def)
 
-    def identify(self, filepath):
+    def identify(self, filepath, url=None):
         """
         Identifies a file of the layer
 
         :param filepath: filepath from AMQP
+        :param url: fully qualified URL of file
 
         :returns: `list` of file properties
         """
 
-        super().identify(filepath)
+        super().identify(filepath, url)
 
         self.model = 'model_gem_regional'
 
@@ -121,7 +122,7 @@ class ModelGemRegionalLayer(BaseLayer):
 
             feature_dict = {
                 'layer_name': layer_name,
-                'filepath': filepath,
+                'filepath': self.filepath,
                 'identifier': identifier,
                 'reference_datetime': reference_datetime.strftime(
                     DATE_FORMAT),

--- a/geomet_data_registry/layer/model_giops.py
+++ b/geomet_data_registry/layer/model_giops.py
@@ -52,13 +52,14 @@ class GiopsLayer(BaseLayer):
         self.dimension = None  # identifies if the layer is 2D or 3D GIOPS data
         self.bands = None
 
-        BaseLayer.__init__(self, provider_def)
+        super().__init__(self, provider_def)
 
-    def identify(self, filepath):
+    def identify(self, filepath, url=None):
         """
         Identifies a file of the layer
 
         :param filepath: filepath from AMQP
+        :param url: fully qualified URL of file
 
         :returns: `list` of file properties
         """

--- a/geomet_data_registry/layer/model_hrdps_continental.py
+++ b/geomet_data_registry/layer/model_hrdps_continental.py
@@ -44,13 +44,14 @@ class ModelHrdpsContinentalLayer(BaseLayer):
 
         provider_def = {'name': 'model_hrdps_continental'}
 
-        BaseLayer.__init__(self, provider_def)
+        super().__init__(self, provider_def)
 
-    def identify(self, filepath):
+    def identify(self, filepath, url=None):
         """
         Identifies a file of the layer
 
         :param filepath: filepath from AMQP
+        :param url: fully qualified URL of file
 
         :returns: `list` of file properties
         """
@@ -121,7 +122,7 @@ class ModelHrdpsContinentalLayer(BaseLayer):
 
             feature_dict = {
                 'layer_name': layer_name,
-                'filepath': filepath,
+                'filepath': self.filepath,
                 'identifier': identifier,
                 'reference_datetime': reference_datetime.strftime(
                     DATE_FORMAT),

--- a/geomet_data_registry/layer/radar_1km.py
+++ b/geomet_data_registry/layer/radar_1km.py
@@ -44,18 +44,19 @@ class Radar1kmLayer(BaseLayer):
 
         provider_def = {'name': 'Radar_1km'}
 
-        BaseLayer.__init__(self, provider_def)
+        super().__init__(self, provider_def)
 
-    def identify(self, filepath):
+    def identify(self, filepath, url=None):
         """
         Identifies a file of the layer
 
         :param filepath: filepath from AMQP
+        :param url: fully qualified URL of file
 
         :returns: `list` of file properties
         """
 
-        super().identify(filepath)
+        super().identify(filepath, url)
 
         self.model = 'radar'
 
@@ -98,7 +99,7 @@ class Radar1kmLayer(BaseLayer):
 
         feature_dict = {
             'layer_name': layer_name,
-            'filepath': filepath,
+            'filepath': self.filepath,
             'identifier': identifier,
             'reference_datetime': None,
             'forecast_hour_datetime': self.date_.strftime(date_format),

--- a/geomet_data_registry/layer/rdpa.py
+++ b/geomet_data_registry/layer/rdpa.py
@@ -44,18 +44,19 @@ class RdpaLayer(BaseLayer):
 
         provider_def = {'name': 'rdpa'}
 
-        BaseLayer.__init__(self, provider_def)
+        super().__init__(self, provider_def)
 
-    def identify(self, filepath):
+    def identify(self, filepath, url=None):
         """
         Identifies a file of the layer
 
         :param filepath: filepath from AMQP
+        :param url: fully qualified URL of file
 
         :returns: `list` of file properties
         """
 
-        super().identify(filepath)
+        super().identify(filepath, url)
 
         self.model = 'rdpa'
 
@@ -144,7 +145,7 @@ class RdpaLayer(BaseLayer):
 
             feature_dict = {
                 'layer_name': layer_name,
-                'filepath': filepath,
+                'filepath': self.filepath,
                 'identifier': identifier,
                 'reference_datetime': None,
                 'forecast_hour_datetime': self.date_.strftime(DATE_FORMAT),

--- a/geomet_data_registry/layer/rdwps.py
+++ b/geomet_data_registry/layer/rdwps.py
@@ -46,18 +46,19 @@ class RdwpsLayer(BaseLayer):
         # self.category identifies if the RDWPS layer is a lake or gulf layer
         self.category = None
 
-        BaseLayer.__init__(self, provider_def)
+        super().__init__(self, provider_def)
 
-    def identify(self, filepath):
+    def identify(self, filepath, url=None):
         """
         Identifies a file of the layer
 
         :param filepath: filepath from AMQP
+        :param url: fully qualified URL of file
 
         :returns: `list` of file properties
         """
 
-        super().identify(filepath)
+        super().identify(filepath, url)
 
         self.model = 'rdwps'
 
@@ -146,7 +147,7 @@ class RdwpsLayer(BaseLayer):
 
             feature_dict = {
                 'layer_name': layer_name,
-                'filepath': filepath,
+                'filepath': self.filepath,
                 'identifier': identifier,
                 'reference_datetime': reference_datetime.strftime(
                     DATE_FORMAT),

--- a/geomet_data_registry/layer/reps.py
+++ b/geomet_data_registry/layer/reps.py
@@ -47,18 +47,19 @@ class RepsLayer(BaseLayer):
         self.type = None
         self.bands = None
 
-        BaseLayer.__init__(self, provider_def)
+        super().__init__(self, provider_def)
 
-    def identify(self, filepath):
+    def identify(self, filepath, url=None):
         """
         Identifies a file of the layer
 
         :param filepath: filepath from AMQP
+        :param url: fully qualified URL of file
 
         :returns: `list` of file properties
         """
 
-        super().identify(filepath)
+        super().identify(filepath, url)
 
         self.model = 'reps'
 

--- a/geomet_data_registry/layer/wcps.py
+++ b/geomet_data_registry/layer/wcps.py
@@ -44,18 +44,19 @@ class WcpsLayer(BaseLayer):
 
         provider_def = {'name': 'wcps'}
 
-        BaseLayer.__init__(self, provider_def)
+        super().__init__(self, provider_def)
 
-    def identify(self, filepath):
+    def identify(self, filepath, url=None):
         """
         Identifies a file of the layer
 
         :param filepath: filepath from AMQP
+        :param url: fully qualified URL of file
 
         :returns: `bool` of identification success status
         """
 
-        super().identify(filepath)
+        super().identify(filepath, url)
 
         self.model = 'wcps'
 
@@ -122,7 +123,7 @@ class WcpsLayer(BaseLayer):
 
             feature_dict = {
                 'layer_name': layer_name,
-                'filepath': filepath,
+                'filepath': self.filepath,
                 'identifier': identifier,
                 'reference_datetime': reference_datetime.strftime(
                     DATE_FORMAT),

--- a/geomet_data_registry/store/redis_.py
+++ b/geomet_data_registry/store/redis_.py
@@ -39,7 +39,7 @@ class RedisStore(BaseStore):
         :returns: `geomet_data_registry.store.redis_.RedisStore`
         """
 
-        BaseStore.__init__(self, provider_def)
+        super().__init__(self, provider_def)
 
         try:
             self.redis = redis.Redis.from_url(self.url,

--- a/geomet_data_registry/tileindex/elasticsearch_.py
+++ b/geomet_data_registry/tileindex/elasticsearch_.py
@@ -142,7 +142,7 @@ class ElasticsearchTileIndex(BaseTileIndex):
         :returns: `geomet_data_registry.tileindex.elasticsearch_.ElasticsearchTileIndex`  # noqa
         """
 
-        BaseTileIndex.__init__(self, provider_def)
+        super().__init__(self, provider_def)
 
         self.url_parsed = urlparse(self.url)
         self.type_name = 'FeatureCollection'


### PR DESCRIPTION
This PR adds an optional URL property to handling workflow so that GDR can manage a tileindex of remote files (which, in our case, can be downloaded on demand based on user-driven requests).

In addition, minor changes to ABC workflow (-> `super().`)