### PR TITLE
Make tileindex url and weather_variable properties arrays

### DIFF
--- a/geomet_data_registry/layer/gdwps.py
+++ b/geomet_data_registry/layer/gdwps.py
@@ -150,6 +150,7 @@ class GdwpsLayer(BaseLayer):
                                    ['variable']
                                    [self.wx_variable].get('bands_order'))
                     (feature_dict['filepath'],
+                     feature_dict['url'],
                      feature_dict['weather_variable']) = (
                         self.configure_layer_with_dependencies(
                             dependencies_found,

--- a/geomet_data_registry/layer/model_gem_global.py
+++ b/geomet_data_registry/layer/model_gem_global.py
@@ -151,6 +151,7 @@ class ModelGemGlobalLayer(BaseLayer):
                                    ['variable']
                                    [self.wx_variable].get('bands_order'))
                     (feature_dict['filepath'],
+                     feature_dict['url'],
                      feature_dict['weather_variable']) = (
                         self.configure_layer_with_dependencies(
                             dependencies_found,

--- a/geomet_data_registry/layer/model_gem_regional.py
+++ b/geomet_data_registry/layer/model_gem_regional.py
@@ -151,6 +151,7 @@ class ModelGemRegionalLayer(BaseLayer):
                                    ['variable']
                                    [self.wx_variable].get('bands_order'))
                     (feature_dict['filepath'],
+                     feature_dict['url'],
                      feature_dict['weather_variable']) = (
                         self.configure_layer_with_dependencies(
                             dependencies_found,

--- a/geomet_data_registry/layer/model_giops.py
+++ b/geomet_data_registry/layer/model_giops.py
@@ -177,6 +177,7 @@ class GiopsLayer(BaseLayer):
                                     'variable'][self.wx_variable].get(
                                     'bands_order'))
                             (feature_dict['filepath'],
+                             feature_dict['url'],
                              feature_dict['weather_variable']) = (
                                 self.configure_layer_with_dependencies(
                                     dependencies_found,
@@ -251,6 +252,7 @@ class GiopsLayer(BaseLayer):
                                 'variable'][self.wx_variable].get(
                                 'bands_order'))
                         (feature_dict['filepath'],
+                         feature_dict['url'],
                          feature_dict['weather_variable']) = (
                             self.configure_layer_with_dependencies(
                                 dependencies_found,

--- a/geomet_data_registry/layer/model_hrdps_continental.py
+++ b/geomet_data_registry/layer/model_hrdps_continental.py
@@ -151,6 +151,7 @@ class ModelHrdpsContinentalLayer(BaseLayer):
                                    ['variable']
                                    [self.wx_variable].get('bands_order'))
                     (feature_dict['filepath'],
+                     feature_dict['url'],
                      feature_dict['weather_variable']) = (
                         self.configure_layer_with_dependencies(
                             dependencies_found,

--- a/geomet_data_registry/layer/rdwps.py
+++ b/geomet_data_registry/layer/rdwps.py
@@ -180,6 +180,7 @@ class RdwpsLayer(BaseLayer):
                                    [self.category]['variable']
                                    [self.wx_variable].get('bands_order'))
                     (feature_dict['filepath'],
+                     feature_dict['url'],
                      feature_dict['weather_variable']) = (
                         self.configure_layer_with_dependencies(
                             dependencies_found,

--- a/geomet_data_registry/layer/wcps.py
+++ b/geomet_data_registry/layer/wcps.py
@@ -152,6 +152,7 @@ class WcpsLayer(BaseLayer):
                                    ['variable']
                                    [self.wx_variable].get('bands_order'))
                     (feature_dict['filepath'],
+                     feature_dict['url'],
                      feature_dict['weather_variable']) = (
                         self.configure_layer_with_dependencies(
                             dependencies_found,


### PR DESCRIPTION
This PR changes indexed documents weather_variable and url properties into arrays and implements multiple url entries for tileindex documents that are composed of two or more weather variables.

See the GDPS.ETA_UU example below.

```json
      "properties":{
         "elevation":"surface",
         "identifier":"GDPS.ETA_UU-20200305000000-20200305210000",
         "reference_datetime":"2020-03-05T00:00:00Z",
         "forecast_hour_datetime":"2020-03-05T21:00:00Z",
         "identify_datetime":"2020-07-02T13:35:01.607538Z",
         "weather_variable":[
            "VGRD_TGL_10",
            "UGRD_TGL_10"
         ],
         "layer":"GDPS.ETA_UU",
         "url":[
            "foo",
            "bar"
         ],
         "file_creation_datetime":"2020-03-05T04:19:07.000000Z",
         "filepath":"foo",
         "member":null,
         "model":"model_gem_global",
         "receive_datetime":"2020-07-02T13:35:01.585698Z",
         "register_datetime":"2020-07-02T13:35:01.609918Z"
      }
   }
}
```