### PR TITLE
use `geomet-data-registry_` prefix on store keys

### DIFF
--- a/geomet_data_registry/layer/cansips.py
+++ b/geomet_data_registry/layer/cansips.py
@@ -62,9 +62,9 @@ class CansipsLayer(BaseLayer):
         self.model = 'cansips'
 
         LOGGER.debug('Loading model information from store')
-        file_dict = json.loads(self.store.get_key(self.model))
+        self.file_dict = json.loads(self.store.get_key(self.model))
 
-        filename_pattern = file_dict[self.model]['filename_pattern']
+        filename_pattern = self.file_dict[self.model]['filename_pattern']
 
         tmp = parse(filename_pattern, os.path.basename(filepath))
 
@@ -80,13 +80,13 @@ class CansipsLayer(BaseLayer):
         LOGGER.debug('Defining the different file properties')
         self.wx_variable = file_pattern_info['wx_variable']
 
-        if self.wx_variable not in file_dict[self.model]['variable']:
+        if self.wx_variable not in self.file_dict[self.model]['variable']:
             msg = 'Variable "{}" not in ' \
                   'configuration file'.format(self.wx_variable)
             LOGGER.warning(msg)
             return False
 
-        weather_var = file_dict[self.model]['variable'][self.wx_variable]
+        weather_var = self.file_dict[self.model]['variable'][self.wx_variable]
         self.geomet_layers = weather_var['geomet_layers']
 
         date_format = '%Y%m'
@@ -96,9 +96,9 @@ class CansipsLayer(BaseLayer):
         self.date_ = reference_datetime
         self.model_run = '{}Z'.format(reference_datetime.strftime('%H'))
 
-        for band in file_dict[self.model]['bands']:
+        for band in self.file_dict[self.model]['bands']:
 
-            dict_bands = file_dict[self.model]['bands']
+            dict_bands = self.file_dict[self.model]['bands']
 
             fhi = dict_bands[band]['forecast_interval']
             fhi = re.sub('[^0-9]', '', fhi)

--- a/geomet_data_registry/store/__init__.py
+++ b/geomet_data_registry/store/__init__.py
@@ -27,7 +27,7 @@ from yaml import load, Loader
 from geomet_data_registry.env import STORE_TYPE, STORE_URL
 from geomet_data_registry.plugin import load_plugin
 from geomet_data_registry.store.base import StoreError
-from geomet_data_registry.util import json_pretty_print
+from geomet_data_registry.util import json_pretty_print, remove_prefix
 
 LOGGER = logging.getLogger(__name__)
 
@@ -158,7 +158,10 @@ def list_keys(ctx, pattern=None):
     st = load_plugin('store', provider_def)
 
     try:
-        click.echo(json_pretty_print(st.list_keys(pattern)))
+        pattern = 'geomet-data-registry*{}'.format(pattern if pattern else '')
+        keys = [remove_prefix(key, 'geomet-data-registry_') for key
+                in st.list_keys(pattern)]
+        click.echo(json_pretty_print(keys))
     except StoreError as err:
         raise click.ClickException(err)
     click.echo('Done')

--- a/geomet_data_registry/store/redis_.py
+++ b/geomet_data_registry/store/redis_.py
@@ -67,22 +67,30 @@ class RedisStore(BaseStore):
         """
 
         LOGGER.debug('Deleting all Redis keys')
-        for key in self.redis.scan_iter():
+        keys = [
+            key for key in self.redis.scan_iter()
+            if key.startswith('geomet-data-registry')
+        ]
+        for key in keys:
             LOGGER.debug('Deleting key {}'.format(key))
             self.redis.delete(key)
 
         return True
 
-    def get_key(self, key):
+    def get_key(self, key, raw=False):
         """
         Get key from store
 
         :param key: key to fetch
 
+        :param raw: `bool` indication whether to add prefix when fetching key
+
         :returns: string of key value from Redis store
         """
+        if raw:
+            return self.redis.get(key)
 
-        return self.redis.get(key)
+        return self.redis.get('geomet-data-registry_{}'.format(key))
 
     def set_key(self, key, value):
         """
@@ -94,7 +102,7 @@ class RedisStore(BaseStore):
         :returns: `bool` of set success
         """
 
-        return self.redis.set(key, value)
+        return self.redis.set('geomet-data-registry_{}'.format(key), value)
 
     def list_keys(self, pattern=None):
         """

--- a/geomet_data_registry/util.py
+++ b/geomet_data_registry/util.py
@@ -148,3 +148,17 @@ def get_today_and_now():
     :returns: Current UTC datetime as `str`
     """
     return datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+
+
+def remove_prefix(text, prefix):
+    """
+    Utility function to remove a given prefix from a string if is present
+
+    :param text: `str` to parse
+    :param prefix: `str` to remove from text
+
+    :returns: `str` of text without prefix, or text if no prefix found
+    """
+    if text.startswith(prefix):
+        return text[len(prefix):]
+    return text


### PR DESCRIPTION
Adds the `geomet-data-registry_` prefix to all keys written to a store.

The prefix is also added to all `store.get_key()` calls.

`geomet-data-registry store list` lists the keys without the prefix, while a `geomet-data-registry get -k <name>` automatically adds the prefix.