### PR TITLE
add --raw flag to store CLI command

### DIFF
--- a/geomet_data_registry/store/redis_.py
+++ b/geomet_data_registry/store/redis_.py
@@ -82,25 +82,29 @@ class RedisStore(BaseStore):
         Get key from store
 
         :param key: key to fetch
-
         :param raw: `bool` indication whether to add prefix when fetching key
 
-        :returns: string of key value from Redis store
+        :returns: `str` of key value from Redis store
         """
+
         if raw:
             return self.redis.get(key)
 
         return self.redis.get('geomet-data-registry_{}'.format(key))
 
-    def set_key(self, key, value):
+    def set_key(self, key, value, raw=False):
         """
         Set key value from
 
         :param key: key to set value
         :param value: value to set
+        :param raw: `bool` indication whether to add prefix when setting key
 
         :returns: `bool` of set success
         """
+
+        if raw:
+            return self.redis.set(key, value)
 
         return self.redis.set('geomet-data-registry_{}'.format(key), value)
 


### PR DESCRIPTION
Adds a `--raw` or `-r` flag to the `geomet-data-registry store [list, get, set]` commands and improves the `click` echoes to show the exact key requested from the store.

For example:
```bash
geomet-data-registry store list -r # show keys with their geomet-data-registry_ prefix
geomet-data-registry store get -r -k geomet-data-registry_GDPS.ETA_TT_model_run_extent # retrieves the key without adding the geomet-data-registry_ prefix
```