### PR TITLE
initial celery task notification implementation

### DIFF
--- a/deploy/default/gdwps.yml
+++ b/deploy/default/gdwps.yml
@@ -108,8 +108,10 @@ gdwps:
                     files_expected: 73
             geomet_layers:
                 GDWPS.UGRD.1h:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 GDWPS.UGRD.3h:
+                    published: False
                     forecast_hours: 000/120/PT3H
                 GDWPS.UU.1h:
                     dependencies:
@@ -132,8 +134,10 @@ gdwps:
                     files_expected: 73
             geomet_layers:
                 GDWPS.VGRD.1h:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 GDWPS.VGRD.3h:
+                    published: False
                     forecast_hours: 000/120/PT3H
                 GDWPS.UU.1h:
                     dependencies:

--- a/deploy/default/model_gem_global.yml
+++ b/deploy/default/model_gem_global.yml
@@ -1831,8 +1831,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_UGRD.1015.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_UGRD.1015.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.1015.3h:
                     dependencies:
@@ -1856,6 +1858,7 @@ model_gem_global:
                     files_expected: 81
             geomet_layers:
                 GDPS.PRES_UGRD.1000:
+                    published: False
                     forecast_hours: 000/240/PT3H
                 GDPS.PRES_UU.1000:
                     dependencies:
@@ -1875,8 +1878,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_UGRD.985.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_UGRD.985.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.985.3h:
                     dependencies:
@@ -1900,8 +1905,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_UGRD.970.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_UGRD.970.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.970.3h:
                     dependencies:
@@ -1925,8 +1932,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_UGRD.950.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_UGRD.950.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.950.3h:
                     dependencies:
@@ -1950,6 +1959,7 @@ model_gem_global:
                     files_expected: 81
             geomet_layers:
                 GDPS.PRES_UGRD.925:
+                    published: False
                     forecast_hours: 000/240/PT3H
                 GDPS.PRES_UU.925:
                     dependencies:
@@ -1969,8 +1979,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_UGRD.900.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_UGRD.900.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.900.3h:
                     dependencies:
@@ -1994,8 +2006,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_UGRD.875.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_UGRD.875.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.875.3h:
                     dependencies:
@@ -2019,6 +2033,7 @@ model_gem_global:
                     files_expected: 81
             geomet_layers:
                 GDPS.PRES_UGRD.850:
+                    published: False
                     forecast_hours: 000/240/PT3H
                 GDPS.PRES_UU.850:
                     dependencies:
@@ -2027,7 +2042,7 @@ model_gem_global:
             bands_order:
                 - UGRD_ISBL
                 - VGRD_ISBL
-                    
+
         UGRD_ISBL_800:
             members: null
             elevation: 800mb
@@ -2038,8 +2053,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_UGRD.800.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_UGRD.800.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.800.3h:
                     dependencies:
@@ -2063,8 +2080,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_UGRD.750.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_UGRD.750.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.750.3h:
                     dependencies:
@@ -2088,6 +2107,7 @@ model_gem_global:
                     files_expected: 81
             geomet_layers:
                 GDPS.PRES_UGRD.700:
+                    published: False
                     forecast_hours: 000/240/PT3H
                 GDPS.PRES_UU.700:
                     dependencies:
@@ -2107,8 +2127,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_UGRD.650.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_UGRD.650.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.650.3h:
                     dependencies:
@@ -2132,8 +2154,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_UGRD.600.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_UGRD.600.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.600.3h:
                     dependencies:
@@ -2157,8 +2181,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_UGRD.550.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_UGRD.550.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.550.3h:
                     dependencies:
@@ -2182,6 +2208,7 @@ model_gem_global:
                     files_expected: 81
             geomet_layers:
                 GDPS.PRES_UGRD.500:
+                    published: False
                     forecast_hours: 000/240/PT3H
                 GDPS.PRES_UU.500:
                     dependencies:
@@ -2201,8 +2228,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_UGRD.450.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_UGRD.450.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.450.3h:
                     dependencies:
@@ -2226,8 +2255,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_UGRD.400.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_UGRD.400.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.400.3h:
                     dependencies:
@@ -2240,7 +2271,7 @@ model_gem_global:
             bands_order:
                 - UGRD_ISBL
                 - VGRD_ISBL
-        
+
         UGRD_ISBL_350:
             members: null
             elevation: 350mb
@@ -2251,8 +2282,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_UGRD.350.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_UGRD.350.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.350.3h:
                     dependencies:
@@ -2276,8 +2309,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_UGRD.300.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_UGRD.300.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.300.3h:
                     dependencies:
@@ -2290,7 +2325,7 @@ model_gem_global:
             bands_order:
                 - UGRD_ISBL
                 - VGRD_ISBL
-        
+
         UGRD_ISBL_275:
             members: null
             elevation: 275mb
@@ -2301,8 +2336,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_UGRD.275.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_UGRD.275.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.275.3h:
                     dependencies:
@@ -2326,8 +2363,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_UGRD.250.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_UGRD.250.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.250.3h:
                     dependencies:
@@ -2340,7 +2379,7 @@ model_gem_global:
             bands_order:
                 - UGRD_ISBL
                 - VGRD_ISBL
-        
+
         UGRD_ISBL_225:
             members: null
             elevation: 225mb
@@ -2351,8 +2390,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_UGRD.225.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_UGRD.225.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.225.3h:
                     dependencies:
@@ -2365,7 +2406,7 @@ model_gem_global:
             bands_order:
                 - UGRD_ISBL
                 - VGRD_ISBL
-        
+
         UGRD_ISBL_200:
             members: null
             elevation: 200mb
@@ -2376,8 +2417,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_UGRD.200.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_UGRD.200.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.200.3h:
                     dependencies:
@@ -2390,7 +2433,7 @@ model_gem_global:
             bands_order:
                 - UGRD_ISBL
                 - VGRD_ISBL
-        
+
         UGRD_ISBL_175:
             members: null
             elevation: 175mb
@@ -2401,8 +2444,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_UGRD.175.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_UGRD.175.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.175.3h:
                     dependencies:
@@ -2415,7 +2460,7 @@ model_gem_global:
             bands_order:
                 - UGRD_ISBL
                 - VGRD_ISBL
-        
+
         UGRD_ISBL_150:
             members: null
             elevation: 150mb
@@ -2426,8 +2471,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_UGRD.150.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_UGRD.150.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.150.3h:
                     dependencies:
@@ -2440,7 +2487,7 @@ model_gem_global:
             bands_order:
                 - UGRD_ISBL
                 - VGRD_ISBL
-                    
+
         UGRD_ISBL_100:
             members: null
             elevation: 100mb
@@ -2451,8 +2498,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_UGRD.100.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_UGRD.100.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.100.3h:
                     dependencies:
@@ -2465,7 +2514,7 @@ model_gem_global:
             bands_order:
                 - UGRD_ISBL
                 - VGRD_ISBL
-                    
+
         UGRD_ISBL_50:
             members: null
             elevation: 50mb
@@ -2476,8 +2525,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_UGRD.50.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_UGRD.50.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.50.3h:
                     dependencies:
@@ -2501,6 +2552,7 @@ model_gem_global:
                     files_expected: 81
             geomet_layers:
                 GDPS.ETA_UGRD:
+                    published: False
                     forecast_hours: 000/240/PT3H
                 GDPS.ETA_UU:
                     dependencies:
@@ -2520,8 +2572,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_VGRD.1015.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_VGRD.1015.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.1015.3h:
                     dependencies:
@@ -2545,6 +2599,7 @@ model_gem_global:
                     files_expected: 81
             geomet_layers:
                 GDPS.PRES_VGRD.1000:
+                    published: False
                     forecast_hours: 000/240/PT3H
                 GDPS.PRES_UU.1000:
                     dependencies:
@@ -2553,7 +2608,7 @@ model_gem_global:
             bands_order:
                 - UGRD_ISBL
                 - VGRD_ISBL
-                    
+
         VGRD_ISBL_985:
             members: null
             elevation: 985mb
@@ -2564,8 +2619,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_VGRD.985.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_VGRD.985.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.985.3h:
                     dependencies:
@@ -2578,7 +2635,7 @@ model_gem_global:
             bands_order:
                 - UGRD_ISBL
                 - VGRD_ISBL
-                    
+
         VGRD_ISBL_970:
             members: null
             elevation: 970mb
@@ -2589,8 +2646,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_VGRD.970.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_VGRD.970.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.970.3h:
                     dependencies:
@@ -2614,8 +2673,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_VGRD.950.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_VGRD.950.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.950.3h:
                     dependencies:
@@ -2639,6 +2700,7 @@ model_gem_global:
                     files_expected: 81
             geomet_layers:
                 GDPS.PRES_VGRD.925:
+                    published: False
                     forecast_hours: 000/240/PT3H
                 GDPS.PRES_UU.925:
                     dependencies:
@@ -2658,8 +2720,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_VGRD.900.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_VGRD.900.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.900.3h:
                     dependencies:
@@ -2683,8 +2747,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_VGRD.875.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_VGRD.875.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.875.3h:
                     dependencies:
@@ -2708,6 +2774,7 @@ model_gem_global:
                     files_expected: 81
             geomet_layers:
                 GDPS.PRES_VGRD.850:
+                    published: False
                     forecast_hours: 000/240/PT3H
                 GDPS.PRES_UU.850:
                     dependencies:
@@ -2716,7 +2783,7 @@ model_gem_global:
             bands_order:
                 - UGRD_ISBL
                 - VGRD_ISBL
-                    
+
         VGRD_ISBL_800:
             members: null
             elevation: 800mb
@@ -2727,8 +2794,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_VGRD.800.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_VGRD.800.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.800.3h:
                     dependencies:
@@ -2752,8 +2821,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_VGRD.750.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_VGRD.750.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.750.3h:
                     dependencies:
@@ -2777,6 +2848,7 @@ model_gem_global:
                     files_expected: 81
             geomet_layers:
                 GDPS.PRES_VGRD.700:
+                    published: False
                     forecast_hours: 000/240/PT3H
                 GDPS.PRES_UU.700:
                     dependencies:
@@ -2796,8 +2868,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_VGRD.650.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_VGRD.650.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.650.3h:
                     dependencies:
@@ -2821,8 +2895,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_VGRD.600.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_VGRD.600.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.600.3h:
                     dependencies:
@@ -2835,7 +2911,7 @@ model_gem_global:
             bands_order:
                 - UGRD_ISBL
                 - VGRD_ISBL
-                    
+
         VGRD_ISBL_550:
             members: null
             elevation: 550mb
@@ -2846,8 +2922,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_VGRD.550.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_VGRD.550.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.550.3h:
                     dependencies:
@@ -2871,6 +2949,7 @@ model_gem_global:
                     files_expected: 81
             geomet_layers:
                 GDPS.PRES_VGRD.500:
+                    published: False
                     forecast_hours: 000/240/PT3H
                 GDPS.PRES_UU.500:
                     dependencies:
@@ -2879,7 +2958,7 @@ model_gem_global:
             bands_order:
                 - UGRD_ISBL
                 - VGRD_ISBL
-                    
+
         VGRD_ISBL_450:
             members: null
             elevation: 450mb
@@ -2890,8 +2969,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_VGRD.450.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_VGRD.450.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.450.3h:
                     dependencies:
@@ -2915,8 +2996,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_VGRD.400.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_VGRD.400.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.400.3h:
                     dependencies:
@@ -2940,8 +3023,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_VGRD.350.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_VGRD.350.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.350.3h:
                     dependencies:
@@ -2954,7 +3039,7 @@ model_gem_global:
             bands_order:
                 - UGRD_ISBL
                 - VGRD_ISBL
-                    
+
         VGRD_ISBL_300:
             members: null
             elevation: 300mb
@@ -2965,8 +3050,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_VGRD.300.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_VGRD.300.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.300.3h:
                     dependencies:
@@ -2990,8 +3077,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_VGRD.275.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_VGRD.275.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.275.3h:
                     dependencies:
@@ -3015,8 +3104,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_VGRD.250.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_VGRD.250.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.250.3h:
                     dependencies:
@@ -3040,8 +3131,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_VGRD.225.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_VGRD.225.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.225.3h:
                     dependencies:
@@ -3065,8 +3158,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_VGRD.200.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_VGRD.200.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.200.3h:
                     dependencies:
@@ -3090,8 +3185,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_VGRD.175.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_VGRD.175.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.175.3h:
                     dependencies:
@@ -3115,8 +3212,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_VGRD.150.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_VGRD.150.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.150.3h:
                     dependencies:
@@ -3140,8 +3239,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_VGRD.100.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_VGRD.100.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.100.3h:
                     dependencies:
@@ -3165,8 +3266,10 @@ model_gem_global:
                     files_expected: 69
             geomet_layers:
                 GDPS.PRES_VGRD.50.3h:
+                    published: False
                     forecast_hours: 000/168/PT3H
                 GDPS.PRES_VGRD.50.6h:
+                    published: False
                     forecast_hours: 000/240/PT6H
                 GDPS.PRES_UU.50.3h:
                     dependencies:
@@ -3190,6 +3293,7 @@ model_gem_global:
                     files_expected: 81
             geomet_layers:
                 GDPS.ETA_VGRD:
+                    published: False
                     forecast_hours: 000/240/PT3H
                 GDPS.ETA_UU:
                     dependencies:

--- a/deploy/default/model_gem_regional.yml
+++ b/deploy/default/model_gem_regional.yml
@@ -2614,6 +2614,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.50:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -2644,6 +2645,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.100:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -2674,6 +2676,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.150:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -2704,6 +2707,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.175:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -2734,6 +2738,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.200:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -2764,6 +2769,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.225:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -2794,6 +2800,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.250:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -2824,6 +2831,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.275:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -2854,6 +2862,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.300:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -2884,6 +2893,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.350:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -2914,6 +2924,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.400:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -2944,6 +2955,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.450:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -2974,6 +2986,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.500:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3004,6 +3017,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.550:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3034,6 +3048,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.600:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3064,6 +3079,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.650:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3094,6 +3110,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.700:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3124,6 +3141,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.750:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3154,6 +3172,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.800:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3184,6 +3203,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.850:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3214,6 +3234,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.875:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3244,6 +3265,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.900:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3274,6 +3296,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.925:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3304,6 +3327,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.950:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3334,6 +3358,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.970:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3364,6 +3389,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.985:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3394,6 +3420,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.1000:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3424,6 +3451,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WD.1015:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3454,6 +3482,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.ETA_WD:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3484,6 +3513,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.50:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3514,6 +3544,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.100:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3544,6 +3575,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.150:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3574,6 +3606,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.175:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3604,6 +3637,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.200:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3634,6 +3668,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.225:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3664,6 +3699,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.250:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3694,6 +3730,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.275:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3724,6 +3761,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.300:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3754,6 +3792,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.350:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3784,6 +3823,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.400:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3814,6 +3854,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.450:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3844,6 +3885,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.500:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3874,6 +3916,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.550:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3904,6 +3947,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.600:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3934,6 +3978,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.650:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3964,6 +4009,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.700:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -3994,6 +4040,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.750:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -4024,6 +4071,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.800:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -4054,6 +4102,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.850:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -4084,6 +4133,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.875:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -4114,6 +4164,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.900:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -4144,6 +4195,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.925:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -4174,6 +4226,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.950:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -4204,6 +4257,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.970:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -4234,6 +4288,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.985:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -4264,6 +4319,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.1000:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -4294,6 +4350,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.PRES_WSPD.1015:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H
@@ -4324,6 +4381,7 @@ model_gem_regional:
                     files_expected: 55
             geomet_layers:
                 RDPS.ETA_WSPD:
+                    published: False
                     forecast_hours:
                         00Z: 000/048/PT1H
                         06Z: 000/054/PT1H

--- a/deploy/default/model_giops.yml
+++ b/deploy/default/model_giops.yml
@@ -139,6 +139,7 @@ model_giops:
                         files_expected: 80
                 geomet_layers:
                     OCEAN.GIOPS.2D.UUY:
+                        published: False
                         forecast_hours: 003/240/PT3H
                     OCEAN.GIOPS.2D.UUI:
                         dependencies:
@@ -157,6 +158,7 @@ model_giops:
                         files_expected: 80
                 geomet_layers:
                     OCEAN.GIOPS.2D.UUX:
+                        published: False
                         forecast_hours: 003/240/PT3H
                     OCEAN.GIOPS.2D.UUI:
                         dependencies:
@@ -175,6 +177,7 @@ model_giops:
                         files_expected: 80
                 geomet_layers:
                     OCEAN.GIOPS.2D.UU2W_Y:
+                        published: False
                         forecast_hours: 003/240/PT3H
                     OCEAN.GIOPS.2D.UU2W:
                         dependencies:
@@ -193,6 +196,7 @@ model_giops:
                         files_expected: 80
                 geomet_layers:
                     OCEAN.GIOPS.2D.UU2W_X:
+                        published: False
                         forecast_hours: 003/240/PT3H
                     OCEAN.GIOPS.2D.UU2W:
                         dependencies:
@@ -685,6 +689,7 @@ model_giops:
                         files_expected: 10
                 geomet_layers:
                     OCEAN.GIOPS.3D_UUW2_X_{}:
+                        published: False
                         forecast_hours: 024/240/PT24H
                     OCEAN.GIOPS.3D_UU2W_{}:
                         dependencies:
@@ -853,6 +858,7 @@ model_giops:
                         files_expected: 10
                 geomet_layers:
                     OCEAN.GIOPS.3D_UUW2_Y_{}:
+                        published: False
                         forecast_hours: 024/240/PT24H
                     OCEAN.GIOPS.3D_UU2W_{}:
                         dependencies:

--- a/deploy/default/model_hrdps_continental.yml
+++ b/deploy/default/model_hrdps_continental.yml
@@ -2458,6 +2458,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.50:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.50:
                     dependencies:
@@ -2480,6 +2481,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.100:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.100:
                     dependencies:
@@ -2502,6 +2504,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.150:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.150:
                     dependencies:
@@ -2524,6 +2527,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.175:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.175:
                     dependencies:
@@ -2546,6 +2550,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.200:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.200:
                     dependencies:
@@ -2568,6 +2573,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.225:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.225:
                     dependencies:
@@ -2590,6 +2596,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.250:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.250:
                     dependencies:
@@ -2612,6 +2619,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.275:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.275:
                     dependencies:
@@ -2634,6 +2642,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.300:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.300:
                     dependencies:
@@ -2656,6 +2665,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.350:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.350:
                     dependencies:
@@ -2678,6 +2688,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.400:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.400:
                     dependencies:
@@ -2700,6 +2711,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.450:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.450:
                     dependencies:
@@ -2722,6 +2734,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.500:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.500:
                     dependencies:
@@ -2744,6 +2757,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.550:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.550:
                     dependencies:
@@ -2766,6 +2780,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.600:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.600:
                     dependencies:
@@ -2788,6 +2803,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.650:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.650:
                     dependencies:
@@ -2810,6 +2826,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.700:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.700:
                     dependencies:
@@ -2832,6 +2849,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.750:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.750:
                     dependencies:
@@ -2854,6 +2872,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.800:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.800:
                     dependencies:
@@ -2876,6 +2895,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.850:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.850:
                     dependencies:
@@ -2898,6 +2918,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.875:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.875:
                     dependencies:
@@ -2920,6 +2941,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.900:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.900:
                     dependencies:
@@ -2942,6 +2964,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.925:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.925:
                     dependencies:
@@ -2964,6 +2987,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.950:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.950:
                     dependencies:
@@ -2986,6 +3010,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.970:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.970:
                     dependencies:
@@ -3008,6 +3033,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.985:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.985:
                     dependencies:
@@ -3030,6 +3056,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.1000:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.1000:
                     dependencies:
@@ -3052,6 +3079,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WD.1015:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.1015:
                     dependencies:
@@ -3074,6 +3102,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL_WD:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL_UU:
                     dependencies:
@@ -3096,6 +3125,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.50:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.50:
                     dependencies:
@@ -3118,6 +3148,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.100:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.100:
                     dependencies:
@@ -3140,6 +3171,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.150:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.150:
                     dependencies:
@@ -3162,6 +3194,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.175:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.175:
                     dependencies:
@@ -3184,6 +3217,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.200:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.200:
                     dependencies:
@@ -3206,6 +3240,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.225:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.225:
                     dependencies:
@@ -3228,6 +3263,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.250:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.250:
                     dependencies:
@@ -3250,6 +3286,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.275:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.275:
                     dependencies:
@@ -3272,6 +3309,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.300:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.300:
                     dependencies:
@@ -3294,6 +3332,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.350:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.350:
                     dependencies:
@@ -3316,6 +3355,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.400:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.400:
                     dependencies:
@@ -3338,6 +3378,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.450:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.450:
                     dependencies:
@@ -3360,6 +3401,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.500:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.500:
                     dependencies:
@@ -3382,6 +3424,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.550:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.550:
                     dependencies:
@@ -3404,6 +3447,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.600:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.600:
                     dependencies:
@@ -3426,6 +3470,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.650:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.650:
                     dependencies:
@@ -3448,6 +3493,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.700:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.700:
                     dependencies:
@@ -3470,6 +3516,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.750:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.750:
                     dependencies:
@@ -3492,6 +3539,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.800:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.800:
                     dependencies:
@@ -3514,6 +3562,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.850:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.850:
                     dependencies:
@@ -3536,6 +3585,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.875:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.875:
                     dependencies:
@@ -3558,6 +3608,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.900:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.900:
                     dependencies:
@@ -3580,6 +3631,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.925:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.925:
                     dependencies:
@@ -3602,6 +3654,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.950:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.950:
                     dependencies:
@@ -3624,6 +3677,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.970:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.970:
                     dependencies:
@@ -3646,6 +3700,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.985:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.985:
                     dependencies:
@@ -3668,6 +3723,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.1000:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.1000:
                     dependencies:
@@ -3690,6 +3746,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL.PRES_WSPD.1015:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL.PRES_UU.1015:
                     dependencies:
@@ -3757,6 +3814,7 @@ model_hrdps_continental:
                     files_expected: 49
             geomet_layers:
                 HRDPS.CONTINENTAL_WSPD:
+                    published: False
                     forecast_hours: 000/048/PT1H
                 HRDPS.CONTINENTAL_UU:
                     dependencies:
@@ -3765,23 +3823,3 @@ model_hrdps_continental:
             bands_order:
                 - WDIR_TGL_10
                 - WIND_TGL_10
-
-
-            
-        
-        
-        
-            
-        
-        
-        
-
-
-
-
-
-        
-
-        
-        
-        

--- a/deploy/default/rdwps.yml
+++ b/deploy/default/rdwps.yml
@@ -155,6 +155,7 @@ rdwps:
                         files_expected: 49
                 geomet_layers:
                     RDWPS.{}.UGRD:
+                        published: False
                         forecast_hours: 000/048/PT1H
                     RDWPS.{}.UU:
                         dependencies:
@@ -177,6 +178,7 @@ rdwps:
                         files_expected: 49
                 geomet_layers:
                     RDWPS.{}.VGRD:
+                        published: False
                         forecast_hours: 000/048/PT1H
                     RDWPS.{}.UU:
                         dependencies:
@@ -365,6 +367,7 @@ rdwps:
                         files_expected: 19
                 geomet_layers:
                     RDWPS.GULF.UGRD:
+                        published: False
                         forecast_hours:
                             00Z: 000/048/PT3H
                             06Z: 000/054/PT3H
@@ -395,6 +398,7 @@ rdwps:
                         files_expected: 19
                 geomet_layers:
                     RDWPS.GULF.VGRD:
+                        published: False
                         forecast_hours:
                             00Z: 000/048/PT3H
                             06Z: 000/054/PT3H

--- a/deploy/default/sarracenia/model_raqdps.conf
+++ b/deploy/default/sarracenia/model_raqdps.conf
@@ -9,5 +9,5 @@ report_back False
 accept .*
 discard ${GDR_METPX_DISCARD}
 #on_file ${GDR_METPX_EVENT_PY}
-on_message ${GDR_METPX_EVENT_PY
+on_message ${GDR_METPX_EVENT_PY}
 chmod_log 0644

--- a/deploy/default/wcps.yml
+++ b/deploy/default/wcps.yml
@@ -61,6 +61,7 @@ wcps:
                     files_expected: 84
             geomet_layers:
                 WCPS.2D_UUI_Y:
+                    published: False
                     forecast_hours: 001/084/PT1H
                 WCPS.2D_UUI:
                     dependencies:
@@ -79,6 +80,7 @@ wcps:
                     files_expected: 84
             geomet_layers:
                 WCPS.2D_UUI_X:
+                    published: False
                     forecast_hours: 001/084/PT1H
                 WCPS.2D_UUI:
                     dependencies:
@@ -130,6 +132,7 @@ wcps:
                     files_expected: 84
             geomet_layers:
                 WCPS.2D_UU_U:
+                    published: False
                     forecast_hours: 001/084/PT1H
                 WCPS.2D_UU:
                     dependencies:
@@ -148,6 +151,7 @@ wcps:
                     files_expected: 84
             geomet_layers:
                 WCPS.2D_UU_V:
+                    published: False
                     forecast_hours: 001/084/PT1H
                 WCPS.2D_UU:
                     dependencies:
@@ -166,6 +170,7 @@ wcps:
                     files_expected: 84
             geomet_layers:
                 WCPS.2D_UU2W_Y:
+                    published: False
                     forecast_hours: 001/084/PT1H
                 WCPS.2D_UU2W:
                     dependencies:
@@ -184,6 +189,7 @@ wcps:
                     files_expected: 84
             geomet_layers:
                 WCPS.2D_UU2W_X:
+                    published: False
                     forecast_hours: 001/084/PT1H
                 WCPS.2D_UU2W:
                     dependencies:

--- a/geomet-data-registry.env
+++ b/geomet-data-registry.env
@@ -13,3 +13,5 @@ export GDR_METPX_NOTIFY=True
 export GDR_GEOMET_ONLY_USER=username
 export GDR_GEOMET_ONLY_PASS=password
 export GDR_GEOMET_ONLY_HOST=example.host.com
+export GDR_NOTIFICATIONS=False
+export GDR_NOTIFICATIONS_URL=redis://localhost:6379

--- a/geomet_data_registry/env.py
+++ b/geomet_data_registry/env.py
@@ -20,6 +20,7 @@
 import logging
 import os
 
+from geomet_data_registry.util import str2bool
 
 LOGGER = logging.getLogger(__name__)
 
@@ -36,6 +37,8 @@ STORE_TYPE = os.environ.get('GDR_STORE_TYPE', None)
 STORE_URL = os.environ.get('GDR_STORE_URL', None)
 METPX_DISCARD = os.environ.get('GDR_METPX_DISCARD', 'on')
 METPX_EVENT_PY = os.environ.get('GDR_METPX_EVENT_PY', None)
+NOTIFICATIONS = str2bool(os.environ.get('GDR_NOTIFICATIONS', False))
+NOTIFICATIONS_URL = os.environ.get('GDR_NOTIFICATIONS_URL', None)
 
 LOGGER.debug(BASEDIR)
 LOGGER.debug(DATADIR)
@@ -45,21 +48,33 @@ LOGGER.debug(TILEINDEX_NAME)
 LOGGER.debug(STORE_TYPE)
 LOGGER.debug(STORE_URL)
 LOGGER.debug(METPX_DISCARD)
+LOGGER.debug(NOTIFICATIONS_URL)
 
-if None in [BASEDIR, DATADIR, TILEINDEX_TYPE, TILEINDEX_BASEURL,
-            TILEINDEX_NAME, STORE_TYPE, STORE_URL, METPX_EVENT_PY]:
+if None in [
+    BASEDIR,
+    DATADIR,
+    TILEINDEX_TYPE,
+    TILEINDEX_BASEURL,
+    TILEINDEX_NAME,
+    STORE_TYPE,
+    STORE_URL,
+    METPX_EVENT_PY,
+]:
     msg = 'Environment variables not set!'
     LOGGER.error(msg)
     raise EnvironmentError(msg)
 
-STORE_PROVIDER_DEF = {
-    'type': STORE_TYPE,
-    'url': STORE_URL
-}
+STORE_PROVIDER_DEF = {'type': STORE_TYPE, 'url': STORE_URL}
 
 TILEINDEX_PROVIDER_DEF = {
     'type': TILEINDEX_TYPE,
     'url': TILEINDEX_BASEURL,
     'name': TILEINDEX_NAME,
     'group': None
+}
+
+NOTIFICATIONS_PROVIDER_DEF = {
+    'type': 'Celery',
+    'active': NOTIFICATIONS,
+    'url': NOTIFICATIONS_URL,
 }

--- a/geomet_data_registry/layer/base.py
+++ b/geomet_data_registry/layer/base.py
@@ -347,6 +347,7 @@ class BaseLayer:
             if 'dependencies' in item['layer_config']:
                 if not self.check_dependencies_default_mr(
                         self.date_, item['layer_config']['dependencies']):
+                    item['refresh_config'] = False
                     LOGGER.debug(
                         'The default model run for at least one '
                         'dependency does not match. '

--- a/geomet_data_registry/layer/cgsl.py
+++ b/geomet_data_registry/layer/cgsl.py
@@ -138,6 +138,7 @@ class CgslLayer(BaseLayer):
                 },
                 'layer_config': layer_config,
                 'register_status': True,
+                'refresh_config': True,
             }
 
             if not self.is_valid_interval(fh, begin, end, interval):

--- a/geomet_data_registry/layer/gdwps.py
+++ b/geomet_data_registry/layer/gdwps.py
@@ -138,6 +138,7 @@ class GdwpsLayer(BaseLayer):
                 },
                 'layer_config': layer_config,
                 'register_status': True,
+                'refresh_config': True,
             }
 
             if 'dependencies' in layer_config:

--- a/geomet_data_registry/layer/geps.py
+++ b/geomet_data_registry/layer/geps.py
@@ -166,6 +166,7 @@ class GepsLayer(BaseLayer):
                     },
                     'layer_config': layer_config,
                     'register_status': True,
+                    'refresh_config': True,
                 }
 
                 if not self.is_valid_interval(fh, begin, end, interval):

--- a/geomet_data_registry/layer/hrdpa.py
+++ b/geomet_data_registry/layer/hrdpa.py
@@ -130,6 +130,7 @@ class HrdpaLayer(BaseLayer):
                 },
                 'layer_config': layer_config,
                 'register_status': True,
+                'refresh_config': True,
             }
             self.items.append(feature_dict)
 

--- a/geomet_data_registry/layer/model_gem_global.py
+++ b/geomet_data_registry/layer/model_gem_global.py
@@ -139,6 +139,7 @@ class ModelGemGlobalLayer(BaseLayer):
                 },
                 'layer_config': layer_config,
                 'register_status': True,
+                'refresh_config': True,
             }
 
             if 'dependencies' in layer_config:

--- a/geomet_data_registry/layer/model_gem_regional.py
+++ b/geomet_data_registry/layer/model_gem_regional.py
@@ -139,6 +139,7 @@ class ModelGemRegionalLayer(BaseLayer):
                 },
                 'layer_config': layer_config,
                 'register_status': True,
+                'refresh_config': True,
             }
 
             if 'dependencies' in layer_config:

--- a/geomet_data_registry/layer/model_giops.py
+++ b/geomet_data_registry/layer/model_giops.py
@@ -161,6 +161,7 @@ class GiopsLayer(BaseLayer):
                         },
                         'layer_config': layer_config,
                         'register_status': True,
+                        'refresh_config': True,
                     }
 
                     if 'dependencies' in layer_config:
@@ -239,6 +240,7 @@ class GiopsLayer(BaseLayer):
                     },
                     'layer_config': layer_config,
                     'register_status': True,
+                    'refresh_config': True,
                 }
 
                 if 'dependencies' in layer_config:

--- a/geomet_data_registry/layer/model_hrdps_continental.py
+++ b/geomet_data_registry/layer/model_hrdps_continental.py
@@ -139,6 +139,7 @@ class ModelHrdpsContinentalLayer(BaseLayer):
                 },
                 'layer_config': layer_config,
                 'register_status': True,
+                'refresh_config': True,
             }
 
             if 'dependencies' in layer_config:

--- a/geomet_data_registry/layer/model_raqdps-fw-ce.py
+++ b/geomet_data_registry/layer/model_raqdps-fw-ce.py
@@ -118,6 +118,7 @@ class ModelRaqdpsFwCeLayer(BaseLayer):
                 'expected_count': None,
                 'layer_config': layer_config,
                 'register_status': True,
+                'refresh_config': True,
             }
 
             self.items.append(feature_dict)

--- a/geomet_data_registry/layer/model_raqdps-fw.py
+++ b/geomet_data_registry/layer/model_raqdps-fw.py
@@ -70,20 +70,22 @@ class ModelRaqdpsFwLayer(BaseLayer):
         file_pattern_info = {
             'wx_variable': tmp.named['wx_variable'],
             'time_': tmp.named['YYYYMMDD_model_run'],
-            'fh': tmp.named['forecast_hour']
+            'fh': tmp.named['forecast_hour'],
         }
 
         LOGGER.debug('Defining the different file properties')
         self.wx_variable = file_pattern_info['wx_variable']
 
         if self.wx_variable not in self.file_dict[self.model]['variable']:
-            msg = 'Variable "{}" not in ' \
-                  'configuration file'.format(self.wx_variable)
+            msg = 'Variable "{}" not in ' 'configuration file'.format(
+                self.wx_variable
+            )
             LOGGER.warning(msg)
             return False
 
         runs = self.file_dict[self.model]['variable'][self.wx_variable][
-            'model_run']
+            'model_run'
+        ]
         self.model_run_list = list(runs.keys())
 
         time_format = '%Y%m%dT%HZ'
@@ -92,40 +94,45 @@ class ModelRaqdpsFwLayer(BaseLayer):
         reference_datetime = self.date_
         self.model_run = '{}Z'.format(self.date_.strftime('%H'))
 
-        forecast_hour_datetime = self.date_ + \
-            timedelta(hours=int(file_pattern_info['fh']))
+        forecast_hour_datetime = self.date_ + timedelta(
+            hours=int(file_pattern_info['fh'])
+        )
 
         member = self.file_dict[self.model]['variable'][self.wx_variable][
-            'members']
+            'members'
+        ]
         elevation = self.file_dict[self.model]['variable'][self.wx_variable][
-            'elevation']
-        str_mr = re.sub('[^0-9]',
-                        '',
-                        reference_datetime.strftime(DATE_FORMAT))
-        str_fh = re.sub('[^0-9]',
-                        '',
-                        forecast_hour_datetime.strftime(DATE_FORMAT))
+            'elevation'
+        ]
+        str_mr = re.sub('[^0-9]', '', reference_datetime.strftime(DATE_FORMAT))
+        str_fh = re.sub(
+            '[^0-9]', '', forecast_hour_datetime.strftime(DATE_FORMAT)
+        )
         expected_count = self.file_dict[self.model]['variable'][
-            self.wx_variable]['model_run'][self.model_run]['files_expected']
+            self.wx_variable
+        ]['model_run'][self.model_run]['files_expected']
 
         self.geomet_layers = self.file_dict[self.model]['variable'][
-            self.wx_variable]['geomet_layers']
+            self.wx_variable
+        ]['geomet_layers']
         for layer_name, layer_config in self.geomet_layers.items():
             identifier = '{}-{}-{}'.format(layer_name, str_mr, str_fh)
 
             forecast_hours = layer_config['forecast_hours']
-            begin, end, interval = [int(re.sub('[^0-9]', '', value))
-                                    for value in forecast_hours.split('/')]
+            begin, end, interval = [
+                int(re.sub('[^0-9]', '', value))
+                for value in forecast_hours.split('/')
+            ]
             fh = int(file_pattern_info['fh'])
 
             feature_dict = {
                 'layer_name': layer_name,
                 'filepath': self.filepath,
                 'identifier': identifier,
-                'reference_datetime': reference_datetime.strftime(
-                    DATE_FORMAT),
+                'reference_datetime': reference_datetime.strftime(DATE_FORMAT),
                 'forecast_hour_datetime': forecast_hour_datetime.strftime(
-                    DATE_FORMAT),
+                    DATE_FORMAT
+                ),
                 'member': member,
                 'model': self.model,
                 'elevation': elevation,
@@ -133,18 +140,22 @@ class ModelRaqdpsFwLayer(BaseLayer):
                 'forecast_hours': {
                     'begin': begin,
                     'end': end,
-                    'interval': forecast_hours.split('/')[2]
+                    'interval': forecast_hours.split('/')[2],
                 },
                 'layer_config': layer_config,
                 'register_status': True,
+                'refresh_config': True,
             }
 
             if not self.is_valid_interval(fh, begin, end, interval):
                 feature_dict['register_status'] = False
-                LOGGER.debug('Forecast hour {} not included in {} as '
-                             'defined for layer {}. File will not be '
-                             'added to registry for this layer'
-                             .format(fh, forecast_hours, layer_name))
+                LOGGER.debug(
+                    'Forecast hour {} not included in {} as '
+                    'defined for layer {}. File will not be '
+                    'added to registry for this layer'.format(
+                        fh, forecast_hours, layer_name
+                    )
+                )
 
             self.items.append(feature_dict)
 

--- a/geomet_data_registry/layer/model_raqdps.py
+++ b/geomet_data_registry/layer/model_raqdps.py
@@ -70,22 +70,24 @@ class ModelRaqdpsLayer(BaseLayer):
         file_pattern_info = {
             'wx_variable': tmp.named['wx_variable'],
             'time_': tmp.named['YYYYMMDD_model_run'],
-            'fh': tmp.named['forecast_hour']
+            'fh': tmp.named['forecast_hour'],
         }
 
         LOGGER.debug('Defining the different file properties')
         self.wx_variable = file_pattern_info['wx_variable']
 
         if self.wx_variable not in self.file_dict[self.model]['variable']:
-            msg = 'Variable "{}" not in ' \
-                  'configuration file'.format(self.wx_variable)
+            msg = 'Variable "{}" not in ' 'configuration file'.format(
+                self.wx_variable
+            )
             LOGGER.warning(msg)
             return False
 
         self.dimensions = self.file_dict[self.model]['dimensions']
 
         runs = self.file_dict[self.model]['variable'][self.wx_variable][
-            'model_run']
+            'model_run'
+        ]
         self.model_run_list = list(runs.keys())
 
         time_format = '%Y%m%dT%HZ'
@@ -94,40 +96,45 @@ class ModelRaqdpsLayer(BaseLayer):
         reference_datetime = self.date_
         self.model_run = '{}Z'.format(self.date_.strftime('%H'))
 
-        forecast_hour_datetime = self.date_ + \
-            timedelta(hours=int(file_pattern_info['fh']))
+        forecast_hour_datetime = self.date_ + timedelta(
+            hours=int(file_pattern_info['fh'])
+        )
 
         member = self.file_dict[self.model]['variable'][self.wx_variable][
-            'members']
+            'members'
+        ]
         elevation = self.file_dict[self.model]['variable'][self.wx_variable][
-            'elevation']
-        str_mr = re.sub('[^0-9]',
-                        '',
-                        reference_datetime.strftime(DATE_FORMAT))
-        str_fh = re.sub('[^0-9]',
-                        '',
-                        forecast_hour_datetime.strftime(DATE_FORMAT))
+            'elevation'
+        ]
+        str_mr = re.sub('[^0-9]', '', reference_datetime.strftime(DATE_FORMAT))
+        str_fh = re.sub(
+            '[^0-9]', '', forecast_hour_datetime.strftime(DATE_FORMAT)
+        )
         expected_count = self.file_dict[self.model]['variable'][
-            self.wx_variable]['model_run'][self.model_run]['files_expected']
+            self.wx_variable
+        ]['model_run'][self.model_run]['files_expected']
 
         self.geomet_layers = self.file_dict[self.model]['variable'][
-            self.wx_variable]['geomet_layers']
+            self.wx_variable
+        ]['geomet_layers']
         for layer_name, layer_config in self.geomet_layers.items():
             identifier = '{}-{}-{}'.format(layer_name, str_mr, str_fh)
 
             forecast_hours = layer_config['forecast_hours']
-            begin, end, interval = [int(re.sub('[^0-9]', '', value))
-                                    for value in forecast_hours.split('/')]
+            begin, end, interval = [
+                int(re.sub('[^0-9]', '', value))
+                for value in forecast_hours.split('/')
+            ]
             fh = int(file_pattern_info['fh'])
 
             feature_dict = {
                 'layer_name': layer_name,
                 'filepath': self.filepath,
                 'identifier': identifier,
-                'reference_datetime': reference_datetime.strftime(
-                    DATE_FORMAT),
+                'reference_datetime': reference_datetime.strftime(DATE_FORMAT),
                 'forecast_hour_datetime': forecast_hour_datetime.strftime(
-                    DATE_FORMAT),
+                    DATE_FORMAT
+                ),
                 'member': member,
                 'model': self.model,
                 'elevation': elevation,
@@ -135,28 +142,28 @@ class ModelRaqdpsLayer(BaseLayer):
                 'forecast_hours': {
                     'begin': begin,
                     'end': end,
-                    'interval': forecast_hours.split('/')[2]
+                    'interval': forecast_hours.split('/')[2],
                 },
                 'layer_config': layer_config,
                 'register_status': True,
+                'refresh_config': True,
             }
 
             if 'dependencies' in layer_config:
                 dependencies_found = self.check_layer_dependencies(
-                    layer_config['dependencies'],
-                    str_mr,
-                    str_fh)
+                    layer_config['dependencies'], str_mr, str_fh
+                )
                 if dependencies_found:
-                    bands_order = (self.file_dict[self.model]
-                                   ['variable']
-                                   [self.wx_variable].get('bands_order'))
-                    (feature_dict['filepath'],
-                     feature_dict['url'],
-                     feature_dict['weather_variable']) = (
-                        self.configure_layer_with_dependencies(
-                            dependencies_found,
-                            self.dimensions,
-                            bands_order))
+                    bands_order = self.file_dict[self.model]['variable'][
+                        self.wx_variable
+                    ].get('bands_order')
+                    (
+                        feature_dict['filepath'],
+                        feature_dict['url'],
+                        feature_dict['weather_variable'],
+                    ) = self.configure_layer_with_dependencies(
+                        dependencies_found, self.dimensions, bands_order
+                    )
                 else:
                     feature_dict['register_status'] = False
                     self.items.append(feature_dict)
@@ -164,10 +171,13 @@ class ModelRaqdpsLayer(BaseLayer):
 
             if not self.is_valid_interval(fh, begin, end, interval):
                 feature_dict['register_status'] = False
-                LOGGER.debug('Forecast hour {} not included in {} as '
-                             'defined for layer {}. File will not be '
-                             'added to registry for this layer'
-                             .format(fh, forecast_hours, layer_name))
+                LOGGER.debug(
+                    'Forecast hour {} not included in {} as '
+                    'defined for layer {}. File will not be '
+                    'added to registry for this layer'.format(
+                        fh, forecast_hours, layer_name
+                    )
+                )
 
             self.items.append(feature_dict)
 

--- a/geomet_data_registry/layer/model_rdaqa-ce.py
+++ b/geomet_data_registry/layer/model_rdaqa-ce.py
@@ -118,6 +118,7 @@ class ModelRdaqaCeLayer(BaseLayer):
                 'expected_count': None,
                 'layer_config': layer_config,
                 'register_status': True,
+                'refresh_config': True,
             }
 
             self.items.append(feature_dict)

--- a/geomet_data_registry/layer/radar_1km.py
+++ b/geomet_data_registry/layer/radar_1km.py
@@ -100,6 +100,7 @@ class Radar1kmLayer(BaseLayer):
 
         feature_dict = {
             'layer_name': layer_name,
+            'layer_config': layer_config,
             'filepath': self.filepath,
             'identifier': identifier,
             'reference_datetime': None,
@@ -110,6 +111,7 @@ class Radar1kmLayer(BaseLayer):
             'expected_count': None,
             'layer_config': layer_config,
             'register_status': True,
+            'refresh_config': True,
         }
         self.items.append(feature_dict)
 

--- a/geomet_data_registry/layer/rdpa.py
+++ b/geomet_data_registry/layer/rdpa.py
@@ -160,6 +160,7 @@ class RdpaLayer(BaseLayer):
                 },
                 'layer_config': layer_config,
                 'register_status': True,
+                'refresh_config': True,
             }
             self.items.append(feature_dict)
 

--- a/geomet_data_registry/layer/rdwps.py
+++ b/geomet_data_registry/layer/rdwps.py
@@ -164,6 +164,7 @@ class RdwpsLayer(BaseLayer):
                 },
                 'layer_config': layer_config,
                 'register_status': True,
+                'refresh_config': True,
             }
 
             if 'dependencies' in layer_config:

--- a/geomet_data_registry/layer/reps.py
+++ b/geomet_data_registry/layer/reps.py
@@ -168,6 +168,7 @@ class RepsLayer(BaseLayer):
                     },
                     'layer_config': layer_config,
                     'register_status': True,
+                    'refresh_config': True,
                 }
 
                 if not self.is_valid_interval(fh, begin, end, interval):

--- a/geomet_data_registry/layer/wcps.py
+++ b/geomet_data_registry/layer/wcps.py
@@ -140,6 +140,7 @@ class WcpsLayer(BaseLayer):
                 },
                 'layer_config': layer_config,
                 'register_status': True,
+                'refresh_config': True,
             }
 
             if 'dependencies' in layer_config:

--- a/geomet_data_registry/notifier/__init__.py
+++ b/geomet_data_registry/notifier/__init__.py
@@ -1,0 +1,18 @@
+###############################################################################
+#
+# Copyright (C) 2020 Etienne Pelletier
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################

--- a/geomet_data_registry/notifier/base.py
+++ b/geomet_data_registry/notifier/base.py
@@ -1,0 +1,46 @@
+###############################################################################
+#
+# Copyright (C) 2020 Etienne Pelletier
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+
+class BaseNotifier:
+    """generic notifier ABC"""
+
+    def __init__(self, provider_def):
+        """
+        Initialize object
+
+        :param provider_def: provider definition dict
+
+        :returns: `geomet_data_registry.notifier.base.BaseNotifier`
+        """
+
+        self.type = provider_def['type']
+        self.url = provider_def['url']
+
+    def __repr__(self):
+        return '<BaseNotifier> {}'.format(self.type)
+
+
+class NotifierError(Exception):
+    """setup error"""
+    pass

--- a/geomet_data_registry/notifier/celery_.py
+++ b/geomet_data_registry/notifier/celery_.py
@@ -1,0 +1,59 @@
+###############################################################################
+#
+# Copyright (C) 2020 Etienne Pelletier
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+import logging
+from celery import Celery
+
+from geomet_data_registry.notifier.base import BaseNotifier
+
+LOGGER = logging.getLogger(__name__)
+
+
+class CeleryTaskNotifier(BaseNotifier):
+    """Celery notifier"""
+
+    def __init__(self, provider_def):
+        """
+        Initialize object
+
+        :param provider_def: provider definition dict
+
+        :returns: `geomet_data_registry.notifier.celery.CeleryTaskNotifier`
+        """
+
+        super().__init__(provider_def)
+
+        self.app = Celery('geomet-mapfile', backend=self.url, broker=self.url)
+
+    def refresh_mapfile(self, items, task_name):
+        """
+        Sends a refresh_mapfile task
+
+        :returns: `bool` of notification status
+        """
+        for item in items:
+            published = item['layer_config'].get('published', True)
+            if item['refresh_config'] and published:
+                self.app.send_task(
+                    'refresh_mapfile', args=[item['layer_name']]
+                )
+        return True
+
+    def __repr__(self):
+        return '<CeleryTaskNotifier> {}'.format(self.url)

--- a/geomet_data_registry/plugin.py
+++ b/geomet_data_registry/plugin.py
@@ -33,6 +33,11 @@ PLUGINS = {
             'path': 'geomet_data_registry.tileindex.elasticsearch_.ElasticsearchTileIndex'  # noqa
         }
     },
+    'notifier': {
+        'Celery': {
+            'path': 'geomet_data_registry.notifier.celery_.CeleryTaskNotifier'
+        }
+    },
     'layer': {
         'ModelGemGlobal': {
             'pattern': 'CMC_glb*',

--- a/geomet_data_registry/util.py
+++ b/geomet_data_registry/util.py
@@ -191,3 +191,21 @@ def parse_iso8601_interval(interval):
             relative_delta = relativedelta(months=int(duration))
 
     return relative_delta
+
+
+def str2bool(value):
+    """
+    helper function to return Python boolean
+    type (source: https://stackoverflow.com/a/715468)
+    :param value: value to be evaluated
+    :returns: `bool` of whether the value is boolean-ish
+    """
+
+    value2 = False
+
+    if isinstance(value, bool):
+        value2 = value
+    else:
+        value2 = value.lower() in ('yes', 'true', 't', '1', 'on')
+
+    return value2


### PR DESCRIPTION
This MR proposes an initial `notifier` module for geomet-data-registry with an initial celery task notification implementation. 

If `GDR_CELERY_NOTIFICATIONS` is set as an environment variable and is True, each time a fully qualified model run is detected for a given weather variable, a `refresh_mapfile` task will be send to `geomet-mapfile`.

