### PR TITLE
refactor plugin definitions

### DIFF
--- a/geomet_data_registry/handler/core.py
+++ b/geomet_data_registry/handler/core.py
@@ -17,31 +17,15 @@
 #
 ###############################################################################
 
+from fnmatch import fnmatch
 import logging
+import os
 
-from geomet_data_registry.plugin import load_plugin
+from geomet_data_registry.plugin import load_plugin, PLUGINS
 from geomet_data_registry.handler.base import BaseHandler
 from geomet_data_registry.util import get_today_and_now
-LOGGER = logging.getLogger(__name__)
 
-DATASET_HANDLERS = {
-    'CMC_glb': 'ModelGemGlobal',
-    'CMC_giops': 'GIOPS',
-    'CMC_reg': 'ModelGemRegional',
-    'CMC_hrdps_continental': 'ModelHrdpsContinental',
-    'RADAR_COMPOSITE_1KM': 'Radar1km',
-    'cansips': 'CanSIPS',
-    'reps': 'REPS',
-    'geps': 'GEPS',
-    'CMC_coupled-rdps-stlawrence': 'CGSL',
-    'CMC_rdwps': 'RDWPS',
-    'CMC_gdwps_global': 'GDWPS',
-    'CMC_wcps': 'WCPS',
-    'CMC_HRDPA': 'HRDPA',
-    'CMC_RDPA': 'RDPA',
-    'MSC_RAQDPS_': 'RAQDPS',
-    'MSC_RAQDPS-FW': 'RAQDPS-FW',
-}
+LOGGER = logging.getLogger(__name__)
 
 
 class CoreHandler(BaseHandler):
@@ -69,10 +53,10 @@ class CoreHandler(BaseHandler):
         """
 
         LOGGER.debug('Detecting filename pattern')
-        for key in DATASET_HANDLERS.keys():
-            if key in self.filepath:
+        for key, value in PLUGINS['layer'].items():
+            if fnmatch(os.path.basename(self.filepath), value['pattern']):
                 plugin_def = {
-                    'type': DATASET_HANDLERS[key],
+                    'type': key,
                 }
                 LOGGER.debug('Loading plugin {}'.format(plugin_def))
                 self.layer_plugin = load_plugin('layer', plugin_def)

--- a/geomet_data_registry/plugin.py
+++ b/geomet_data_registry/plugin.py
@@ -24,29 +24,81 @@ LOGGER = logging.getLogger(__name__)
 
 PLUGINS = {
     'store': {
-        'Redis': 'geomet_data_registry.store.redis_.RedisStore'
+        'Redis': {
+            'path': 'geomet_data_registry.store.redis_.RedisStore'
+        }
     },
     'tileindex': {
-        'Elasticsearch': 'geomet_data_registry.tileindex.elasticsearch_.ElasticsearchTileIndex'  # noqa
+        'Elasticsearch': {
+            'path': 'geomet_data_registry.tileindex.elasticsearch_.ElasticsearchTileIndex'  # noqa
+        }
     },
     'layer': {
-        'ModelGemGlobal': 'geomet_data_registry.layer.model_gem_global.ModelGemGlobalLayer',  # noqa
-        'ModelGemRegional': 'geomet_data_registry.layer.model_gem_regional.ModelGemRegionalLayer',  # noqa
-        'ModelHrdpsContinental': 'geomet_data_registry.layer.model_hrdps_continental.ModelHrdpsContinentalLayer',  # noqa
-        'Radar1km': 'geomet_data_registry.layer.radar_1km.Radar1kmLayer',
-        'CanSIPS': 'geomet_data_registry.layer.cansips.CansipsLayer',
-        'REPS': 'geomet_data_registry.layer.reps.RepsLayer',
-        'GEPS': 'geomet_data_registry.layer.geps.GepsLayer',
-        'GIOPS': 'geomet_data_registry.layer.model_giops.GiopsLayer',
-        'CGSL': 'geomet_data_registry.layer.cgsl.CgslLayer',
-        'RDWPS': 'geomet_data_registry.layer.rdwps.RdwpsLayer',
-        'GDWPS': 'geomet_data_registry.layer.gdwps.GdwpsLayer',
-        'WCPS': 'geomet_data_registry.layer.wcps.WcpsLayer',
-        'HRDPA': 'geomet_data_registry.layer.hrdpa.HrdpaLayer',
-        'RDPA': 'geomet_data_registry.layer.rdpa.RdpaLayer',
-        'RAQDPS': 'geomet_data_registry.layer.model_raqdps.ModelRaqdpsLayer',  # noqa
-        'RAQDPS-FW': 'geomet_data_registry.layer.model_raqdps-fw.ModelRaqdpsFwLayer',  # noqa
-    }
+        'ModelGemGlobal': {
+            'pattern': 'CMC_glb*',
+            'path': 'geomet_data_registry.layer.model_gem_global.ModelGemGlobalLayer',  # noqa
+        },
+        'ModelGemRegional': {
+            'pattern': 'CMC_reg*',
+            'path': 'geomet_data_registry.layer.model_gem_regional.ModelGemRegionalLayer',  # noqa
+        },
+        'ModelHrdpsContinental': {
+            'pattern': 'CMC_hrdps_continental*',
+            'path': 'geomet_data_registry.layer.model_hrdps_continental.ModelHrdpsContinentalLayer',  # noqa
+        },
+        'Radar1km': {
+            'pattern': '*RADAR_COMPOSITE_1KM*',
+            'path': 'geomet_data_registry.layer.radar_1km.Radar1kmLayer',
+        },
+        'CanSIPS': {
+            'pattern': 'cansips*',
+            'path': 'geomet_data_registry.layer.cansips.CansipsLayer',
+        },
+        'REPS': {
+            'pattern': 'CMC-reps*',
+            'path': 'geomet_data_registry.layer.reps.RepsLayer',
+        },
+        'GEPS': {
+            'pattern': 'CMC-geps*',
+            'path': 'geomet_data_registry.layer.geps.GepsLayer',
+        },
+        'GIOPS': {
+            'pattern': 'CMC_giops*',
+            'path': 'geomet_data_registry.layer.model_giops.GiopsLayer',
+        },
+        'CGSL': {
+            'pattern': 'CMC_coupled-rdps-stlawrence*',
+            'path': 'geomet_data_registry.layer.cgsl.CgslLayer',
+        },
+        'RDWPS': {
+            'pattern': 'CMC_rdwps*',
+            'path': 'geomet_data_registry.layer.rdwps.RdwpsLayer',
+        },
+        'GDWPS': {
+            'pattern': 'CMC_gdwps_global*',
+            'path': 'geomet_data_registry.layer.gdwps.GdwpsLayer',
+        },
+        'WCPS': {
+            'pattern': 'CMC_wcps*',
+            'path': 'geomet_data_registry.layer.wcps.WcpsLayer',
+        },
+        'HRDPA': {
+            'pattern': 'CMC_HRDPA*',
+            'path': 'geomet_data_registry.layer.hrdpa.HrdpaLayer',
+        },
+        'RDPA': {
+            'pattern': 'CMC_RDPA*',
+            'path': 'geomet_data_registry.layer.rdpa.RdpaLayer',
+        },
+        'RAQDPS': {
+            'pattern': '*MSC_RAQDPS*',
+            'path': 'geomet_data_registry.layer.model_raqdps.ModelRaqdpsLayer',
+        },
+        'RAQDPS-FW': {
+            'pattern': '*MSC_RAQDPS-FW_*.grib2',
+            'path': 'geomet_data_registry.layer.model_raqdps-fw.ModelRaqdpsFwLayer',  # noqa
+        },
+    },
 }
 
 
@@ -77,9 +129,9 @@ def load_plugin(plugin_type, plugin_def):
         raise InvalidPluginError(msg)
 
     if '.' in type_:  # dotted path
-        packagename, classname = type_.rsplit('.', 1)
+        packagename, classname = type_['path'].rsplit('.', 1)
     else:  # core formatter
-        packagename, classname = plugin_list[type_].rsplit('.', 1)
+        packagename, classname = plugin_list[type_]['path'].rsplit('.', 1)
 
     LOGGER.debug('package name: {}'.format(packagename))
     LOGGER.debug('class name: {}'.format(classname))


### PR DESCRIPTION
This merge request aims to improve the way we define plugin definitions, and the way we handle identifying received filepaths from AMQP notifications.

In regards to the layer plugins, this MR merges the information previously held in the `DATASET_HANDLERS` dict in `geomet_data_registry/handler/core.py`  into the actual plugin definition itself (see the `pattern` key for layer-type plugins in `geomet_data_registry/plugin.py`). The `pattern` key is now a  unix shell-style pattern (with wildcard support), allowing us much more flexibility in the way we associate a layer plugin to an incoming filepath. Using the `fnmatch` standard library, we can then match the pattern to the filepath's basename. This improves on the previous method where we only checked if a substring was found in the entire filepath. In some instances, a substring could be found in two filepaths that we would ultimately send to different loaders. See below:

`20201123T00Z_MSC_RAQDPS-FW_PM10_SFC_RLatLon0.09x0.09_P000.grib2`
and
`20190601T00Z_MSC_RAQDPS-FW_PM2.5-DIFF-MAvg-DMax_SFC_RLatLon0.09x0.09_P1M.nc`

Previously the `RAQDPS-FW_` substring would be found for both of these files. Now that we use unix shell-style file pattern matching we can distinguish between these two with `MSC_RAQDPS-FW*.grib2` and `MSC_RAQDPS-FW*.nc` and send them to their respective loaders (RAWDPS-FW loader and the upcoming RAQDPS-FW Cumulative Effects loader).
