### PR TITLE
ensure default time is updated for cumulative effects loaders

### DIFF
--- a/geomet_data_registry/layer/model_raqdps-fw-ce.py
+++ b/geomet_data_registry/layer/model_raqdps-fw-ce.py
@@ -178,6 +178,12 @@ class ModelRaqdpsFwCeLayer(BaseLayer):
                         )
                     )
 
+                if previous_default_time < self.date_:
+                    self.store.set_key(
+                        default_time_key_name,
+                        new_date_str
+                    )
+
                 if self.date_ < previous_interval_begin:
                     self.store.set_key(
                         default_extent_key_name,

--- a/geomet_data_registry/layer/model_rdaqa-ce.py
+++ b/geomet_data_registry/layer/model_rdaqa-ce.py
@@ -178,6 +178,12 @@ class ModelRdaqaCeLayer(BaseLayer):
                         )
                     )
 
+                if previous_default_time < self.date_:
+                    self.store.set_key(
+                        default_time_key_name,
+                        new_date_str
+                    )
+
                 if self.date_ < previous_interval_begin:
                     self.store.set_key(
                         default_extent_key_name,


### PR DESCRIPTION
Fixes an issue where a cumulative effects layer would not have its default_time key value updated when a more recent file was handled.