### PR TITLE
Ensure broker connection can be established upon CeleryTaskNotifier instantiation

### DIFF
--- a/geomet_data_registry/notifier/base.py
+++ b/geomet_data_registry/notifier/base.py
@@ -55,3 +55,8 @@ class BaseNotifier:
 class NotifierError(Exception):
     """setup error"""
     pass
+
+
+class NotifierConnectionError(Exception):
+    """setup error"""
+    pass


### PR DESCRIPTION
Ensures that a connection to the Celery broker can be made when instantiating a CeleryTaskNotifier object. Works for both `redis://localhost:6379` and `amqp://localhost:5672` URI schemes.