### PR TITLE
RIOPS initial loader and config and misc model fixes

### DIFF
--- a/deploy/default/model_gem_regional.yml
+++ b/deploy/default/model_gem_regional.yml
@@ -12,1005 +12,769 @@ model_gem_regional:
             elevation: 250mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_QQ.250:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         ABSV_ISBL_500:
             members: null
             elevation: 500mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_QQ.500:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         ABSV_ISBL_700:
             members: null
             elevation: 700mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_QQ.700:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         ABSV_ISBL_850:
             members: null
             elevation: 850mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_QQ.850:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         ALBDO_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.ETA_AL:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         CAPE_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_SFC-CAPE:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         CIN_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_SFC-CIN:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         DEPR_ISBL_50:
             members: null
             elevation: 50mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.50:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_100:
             members: null
             elevation: 100mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.100:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_150:
             members: null
             elevation: 150mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.150:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_175:
             members: null
             elevation: 175mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.175:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_200:
             members: null
             elevation: 200mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.200:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_225:
             members: null
             elevation: 225mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.225:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_250:
             members: null
             elevation: 250mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.250:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_275:
             members: null
             elevation: 275mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.275:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_300:
             members: null
             elevation: 300mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.300:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_350:
             members: null
             elevation: 350mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.350:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_400:
             members: null
             elevation: 400mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.400:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_450:
             members: null
             elevation: 450mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.450:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_500:
             members: null
             elevation: 500mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.500:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_550:
             members: null
             elevation: 550mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.550:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_600:
             members: null
             elevation: 600mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.600:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_650:
             members: null
             elevation: 650mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.650:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_700:
             members: null
             elevation: 700mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.700:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_750:
             members: null
             elevation: 750mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.750:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_800:
             members: null
             elevation: 800mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.800:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_850:
             members: null
             elevation: 850mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.850:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_875:
             members: null
             elevation: 850mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.875:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_900:
             members: null
             elevation: 900mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.900:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_925:
             members: null
             elevation: 925mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.925:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_950:
             members: null
             elevation: 950mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.950:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_970:
             members: null
             elevation: 970mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.970:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_985:
             members: null
             elevation: 985mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.985:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_1000:
             members: null
             elevation: 1000mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.1000:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_ISBL_1015:
             members: null
             elevation: 1015mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_ES.1015:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         DEPR_TGL_2:
             members: null
             elevation: 2m
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.ETA_ES:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         PRATE_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 48
+                    files_expected: 84
                 06Z:
-                    files_expected: 54
+                    files_expected: 84
                 12Z:
-                    files_expected: 48
+                    files_expected: 84
                 18Z:
-                    files_expected: 54
+                    files_expected: 84
             geomet_layers:
                 RDPS.ETA_RT:
-                    forecast_hours:
-                        00Z: 001/048/PT1H
-                        06Z: 001/054/PT1H
-                        12Z: 001/048/PT1H
-                        18Z: 001/054/PT1H
+                    forecast_hours: 001/084/PT1H
         DPT_TGL_2:
             members: null
             elevation: 2m
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.ETA_TD:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         GUST_MAX_TGL_10:
             members: null
             elevation: 10m
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.ETA_WGX:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         GUST_MIN_TGL_10:
             members: null
             elevation: 10m
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.ETA_WGN:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         GUST_TGL_10:
             members: null
             elevation: 10m
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.ETA_WGE:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         HGT_ISBL_50:
             members: null
             elevation: 50mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_GZ.50:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_GZ.50-CONTOUR:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         HGT_ISBL_100:
             members: null
             elevation: 100mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_GZ.100:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_GZ.100-CONTOUR:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         HGT_ISBL_200:
             members: null
             elevation: 200mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_GZ.200:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_GZ.200-CONTOUR:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         HGT_ISBL_250:
             members: null
             elevation: 250mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_GZ.250:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_GZ.250-CONTOUR:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         HGT_ISBL_500:
             members: null
             elevation: 500mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_GZ.500:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_GZ.500-CONTOUR:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         HGT_ISBL_700:
             members: null
             elevation: 700mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_GZ.700:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_GZ.700-CONTOUR:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         HGT_ISBL_850:
             members: null
             elevation: 850mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_GZ.700:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_GZ.700-CONTOUR:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         HGT_ISBL_925:
             members: null
             elevation: 925mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_GZ.925:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_GZ.925-CONTOUR:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         HGT_ISBL_1000:
             members: null
             elevation: 1000mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_GZ.1000:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_GZ.1000-CONTOUR:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         HGT_SFC_0:
             members: null
             elevation: surface
@@ -1025,1609 +789,1260 @@ model_gem_regional:
                     files_expected: 1
             geomet_layers:
                 RDPS.ETA_GZ:
-                    forecast_hours:
-                        00Z: 000/000/PT0H
-                        06Z: 000/000/PT0H
-                        12Z: 000/000/PT0H
-                        18Z: 000/000/PT0H
+                    forecast_hours: 000/000/PT0H
                 RDPS.ETA_GZ-CONTOUR:
-                    forecast_hours:
-                        00Z: 000/000/PT0H
-                        06Z: 000/000/PT0H
-                        12Z: 000/000/PT0H
-                        18Z: 000/000/PT0H
+                    forecast_hours: 000/000/PT0H
         HPBL_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.ETA_HPBL:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         KX_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_KINDEX.PT3H:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         PRES_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.ETA_P0:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         PRMSL_MSL_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.ETA_PN:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.ETA_PN-SLP:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         PTYPE_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.DIAG_PTYPE.PT3H:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         RH_ISBL_500:
             members: null
             elevation: 500mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HR.500:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         RH_ISBL_700:
             members: null
             elevation: 700mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HR.700:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         RH_ISBL_850:
             members: null
             elevation: 850mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HR.850:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         RH_ISBL_925:
             members: null
             elevation: 925mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HR.925:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         RH_ISBL_1000:
             members: null
             elevation: 1000mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HR.1000:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         RH_TGL_2:
             members: null
             elevation: 2m
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.ETA_HR:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SFCWRO_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 84
                 06Z:
-                    files_expected: 55
+                    files_expected: 84
                 12Z:
-                    files_expected: 49
+                    files_expected: 84
                 18Z:
-                    files_expected: 55
+                    files_expected: 84
             geomet_layers:
                 RDPS.ETA_NO:
-                    forecast_hours:
-                        00Z: 001/048/PT1H
-                        06Z: 001/054/PT1H
-                        12Z: 001/048/PT1H
-                        18Z: 001/054/PT1H
+                    forecast_hours: 001/084/PT1H
         SHWINX_ISBL_500:
             members: null
             elevation: 500mb
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_SHWINX.500:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         SKINT_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.ETA_SKINT:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SOILVIC_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.ETA_I2:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SOILW_DBLL_100:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.ETA_I1:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_50:
             members: null
             elevation: 50mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.50:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_100:
             members: null
             elevation: 100mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.100:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_150:
             members: null
             elevation: 150mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.150:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_175:
             members: null
             elevation: 175mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.175:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_200:
             members: null
             elevation: 200mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.200:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_225:
             members: null
             elevation: 225mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.225:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_250:
             members: null
             elevation: 250mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.250:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_275:
             members: null
             elevation: 275mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.275:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_300:
             members: null
             elevation: 300mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.300:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_350:
             members: null
             elevation: 350mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.350:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_400:
             members: null
             elevation: 400mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.400:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_450:
             members: null
             elevation: 450mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.450:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_500:
             members: null
             elevation: 500mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.500:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_550:
             members: null
             elevation: 550mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.550:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_600:
             members: null
             elevation: 600mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.600:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_650:
             members: null
             elevation: 650mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.650:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_700:
             members: null
             elevation: 700mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.700:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_750:
             members: null
             elevation: 750mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.750:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_800:
             members: null
             elevation: 800mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.800:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_850:
             members: null
             elevation: 850mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.850:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_875:
             members: null
             elevation: 875mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.875:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_900:
             members: null
             elevation: 900mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.900:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_925:
             members: null
             elevation: 925mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.925:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_950:
             members: null
             elevation: 950mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.950:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_970:
             members: null
             elevation: 970mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.970:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_985:
             members: null
             elevation: 985mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.985:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_1000:
             members: null
             elevation: 1000mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.1000:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_ISBL_1015:
             members: null
             elevation: 1015mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU.1015:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         SPFH_SFC_0:
             members: null
             elevation: 1015mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_HU:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TCDC_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.ETA_NT:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_50:
             members: null
             elevation: 50mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.50:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_100:
             members: null
             elevation: 100mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.100:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_150:
             members: null
             elevation: 150mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.150:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_175:
             members: null
             elevation: 175mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.175:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_200:
             members: null
             elevation: 200mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.200:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_225:
             members: null
             elevation: 225mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.225:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_250:
             members: null
             elevation: 250mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.250:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_275:
             members: null
             elevation: 275mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.275:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_300:
             members: null
             elevation: 300mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.300:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_350:
             members: null
             elevation: 350mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.350:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_400:
             members: null
             elevation: 400mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.400:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_450:
             members: null
             elevation: 450mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.450:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_500:
             members: null
             elevation: 500mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.500:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_550:
             members: null
             elevation: 550mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.550:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_600:
             members: null
             elevation: 600mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.600:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_650:
             members: null
             elevation: 650mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.650:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_700:
             members: null
             elevation: 700mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.700:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_750:
             members: null
             elevation: 750mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.750:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_800:
             members: null
             elevation: 800mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.800:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_850:
             members: null
             elevation: 850mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.850:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_875:
             members: null
             elevation: 875mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.875:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_900:
             members: null
             elevation: 900mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.900:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_925:
             members: null
             elevation: 925mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.925:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_950:
             members: null
             elevation: 950mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.950:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_970:
             members: null
             elevation: 970mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.970:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_985:
             members: null
             elevation: 985mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.985:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_1000:
             members: null
             elevation: 1000mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.1000:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_ISBL_1015:
             members: null
             elevation: 1015mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_TT.1015:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TMP_TGL_2:
             members: null
             elevation: 2m
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.ETA_TT:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TOTALX_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_TOTALX.PT3H:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         TSOIL_DBLL_100:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.ETA_I0.100:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         TSOIL_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.ETA_I0:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         VVEL_ISBL_250:
             members: null
             elevation: 250mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WP.250:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         VVEL_ISBL_500:
             members: null
             elevation: 500mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WP.500:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         VVEL_ISBL_700:
             members: null
             elevation: 700mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WP.700:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         VVEL_ISBL_850:
             members: null
             elevation: 850mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WP.850:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         WDIR_ISBL_50:
             members: null
             elevation: 50mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.50:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.50:
                     dependencies:
                         - RDPS.PRES_WSPD.50
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_50
                 - WIND_ISBL_50
@@ -2636,29 +2051,20 @@ model_gem_regional:
             elevation: 100mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.100:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.100:
                     dependencies:
                         - RDPS.PRES_WSPD.100
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_100
                 - WIND_ISBL_100
@@ -2667,29 +2073,20 @@ model_gem_regional:
             elevation: 150mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.150:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.150:
                     dependencies:
                         - RDPS.PRES_WSPD.150
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_150
                 - WIND_ISBL_150
@@ -2698,29 +2095,20 @@ model_gem_regional:
             elevation: 175mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.175:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.175:
                     dependencies:
                         - RDPS.PRES_WSPD.175
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_175
                 - WIND_ISBL_175
@@ -2729,29 +2117,20 @@ model_gem_regional:
             elevation: 200mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.200:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.200:
                     dependencies:
                         - RDPS.PRES_WSPD.200
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_200
                 - WIND_ISBL_200
@@ -2760,29 +2139,20 @@ model_gem_regional:
             elevation: 225mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.225:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.225:
                     dependencies:
                         - RDPS.PRES_WSPD.225
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_225
                 - WIND_ISBL_225
@@ -2791,29 +2161,20 @@ model_gem_regional:
             elevation: 250mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.250:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.250:
                     dependencies:
                         - RDPS.PRES_WSPD.250
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_250
                 - WIND_ISBL_250
@@ -2822,29 +2183,20 @@ model_gem_regional:
             elevation: 275mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.275:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.275:
                     dependencies:
                         - RDPS.PRES_WSPD.275
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_275
                 - WIND_ISBL_275
@@ -2853,29 +2205,20 @@ model_gem_regional:
             elevation: 300mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.300:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.300:
                     dependencies:
                         - RDPS.PRES_WSPD.300
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_300
                 - WIND_ISBL_300
@@ -2884,29 +2227,20 @@ model_gem_regional:
             elevation: 350mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.350:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.350:
                     dependencies:
                         - RDPS.PRES_WSPD.350
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_350
                 - WIND_ISBL_350
@@ -2915,29 +2249,20 @@ model_gem_regional:
             elevation: 400mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.400:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.400:
                     dependencies:
                         - RDPS.PRES_WSPD.400
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_400
                 - WIND_ISBL_400
@@ -2946,29 +2271,20 @@ model_gem_regional:
             elevation: 450mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.450:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.450:
                     dependencies:
                         - RDPS.PRES_WSPD.450
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_450
                 - WIND_ISBL_450
@@ -2977,29 +2293,20 @@ model_gem_regional:
             elevation: 500mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.500:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.500:
                     dependencies:
                         - RDPS.PRES_WSPD.500
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_500
                 - WIND_ISBL_500
@@ -3008,29 +2315,20 @@ model_gem_regional:
             elevation: 550mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.550:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.550:
                     dependencies:
                         - RDPS.PRES_WSPD.550
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_550
                 - WIND_ISBL_550
@@ -3039,29 +2337,20 @@ model_gem_regional:
             elevation: 600mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.600:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.600:
                     dependencies:
                         - RDPS.PRES_WSPD.600
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_600
                 - WIND_ISBL_600
@@ -3070,29 +2359,20 @@ model_gem_regional:
             elevation: 650mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.650:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.650:
                     dependencies:
                         - RDPS.PRES_WSPD.650
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_650
                 - WIND_ISBL_650
@@ -3101,29 +2381,20 @@ model_gem_regional:
             elevation: 700mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.700:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.700:
                     dependencies:
                         - RDPS.PRES_WSPD.700
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_700
                 - WIND_ISBL_700
@@ -3132,29 +2403,20 @@ model_gem_regional:
             elevation: 750mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.750:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.750:
                     dependencies:
                         - RDPS.PRES_WSPD.750
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_750
                 - WIND_ISBL_750
@@ -3163,29 +2425,20 @@ model_gem_regional:
             elevation: 800mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.800:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.800:
                     dependencies:
                         - RDPS.PRES_WSPD.800
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_800
                 - WIND_ISBL_800
@@ -3194,29 +2447,20 @@ model_gem_regional:
             elevation: 850mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.850:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.850:
                     dependencies:
                         - RDPS.PRES_WSPD.850
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_850
                 - WIND_ISBL_850
@@ -3225,29 +2469,20 @@ model_gem_regional:
             elevation: 875mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.875:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.875:
                     dependencies:
                         - RDPS.PRES_WSPD.875
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_875
                 - WIND_ISBL_875
@@ -3256,29 +2491,20 @@ model_gem_regional:
             elevation: 900mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.900:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.900:
                     dependencies:
                         - RDPS.PRES_WSPD.900
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_900
                 - WIND_ISBL_900
@@ -3287,29 +2513,20 @@ model_gem_regional:
             elevation: 925mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.925:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.925:
                     dependencies:
                         - RDPS.PRES_WSPD.925
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_925
                 - WIND_ISBL_925
@@ -3318,29 +2535,20 @@ model_gem_regional:
             elevation: 950mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.950:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.950:
                     dependencies:
                         - RDPS.PRES_WSPD.950
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_950
                 - WIND_ISBL_950
@@ -3349,29 +2557,20 @@ model_gem_regional:
             elevation: 970mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.970:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.970:
                     dependencies:
                         - RDPS.PRES_WSPD.970
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_970
                 - WIND_ISBL_970
@@ -3380,29 +2579,20 @@ model_gem_regional:
             elevation: 985mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.985:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.985:
                     dependencies:
                         - RDPS.PRES_WSPD.985
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_985
                 - WIND_ISBL_985
@@ -3411,29 +2601,20 @@ model_gem_regional:
             elevation: 1000mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.1000:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.1000:
                     dependencies:
                         - RDPS.PRES_WSPD.1000
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_1000
                 - WIND_ISBL_1000
@@ -3442,29 +2623,20 @@ model_gem_regional:
             elevation: 1015mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WD.1015:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.1015:
                     dependencies:
                         - RDPS.PRES_WSPD.1015
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_1015
                 - WIND_ISBL_1015
@@ -3473,29 +2645,20 @@ model_gem_regional:
             elevation: 10m
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.ETA_WD:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.ETA_UU:
                     dependencies:
                         - RDPS.ETA_WSPD
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_TGL_10
                 - WIND_TGL_10
@@ -3504,29 +2667,20 @@ model_gem_regional:
             elevation: 50mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.50:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.50:
                     dependencies:
                         - RDPS.PRES_WD.50
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_50
                 - WIND_ISBL_50
@@ -3535,29 +2689,20 @@ model_gem_regional:
             elevation: 100mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.100:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.100:
                     dependencies:
                         - RDPS.PRES_WD.100
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_100
                 - WIND_ISBL_100
@@ -3566,29 +2711,20 @@ model_gem_regional:
             elevation: 150mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.150:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.150:
                     dependencies:
                         - RDPS.PRES_WD.150
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_150
                 - WIND_ISBL_150
@@ -3597,29 +2733,20 @@ model_gem_regional:
             elevation: 175mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.175:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.175:
                     dependencies:
                         - RDPS.PRES_WD.175
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_175
                 - WIND_ISBL_175
@@ -3628,29 +2755,20 @@ model_gem_regional:
             elevation: 200mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.200:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.200:
                     dependencies:
                         - RDPS.PRES_WD.200
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_200
                 - WIND_ISBL_200
@@ -3659,29 +2777,20 @@ model_gem_regional:
             elevation: 225mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.225:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.225:
                     dependencies:
                         - RDPS.PRES_WD.225
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_225
                 - WIND_ISBL_225
@@ -3690,29 +2799,20 @@ model_gem_regional:
             elevation: 250mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.250:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.250:
                     dependencies:
                         - RDPS.PRES_WD.250
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_250
                 - WIND_ISBL_250
@@ -3721,29 +2821,20 @@ model_gem_regional:
             elevation: 275mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.275:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.275:
                     dependencies:
                         - RDPS.PRES_WD.275
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_275
                 - WIND_ISBL_275
@@ -3752,29 +2843,20 @@ model_gem_regional:
             elevation: 300mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.300:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.300:
                     dependencies:
                         - RDPS.PRES_WD.300
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_300
                 - WIND_ISBL_300
@@ -3783,29 +2865,20 @@ model_gem_regional:
             elevation: 350mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.350:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.350:
                     dependencies:
                         - RDPS.PRES_WD.350
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_350
                 - WIND_ISBL_350
@@ -3814,29 +2887,20 @@ model_gem_regional:
             elevation: 400mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.400:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.400:
                     dependencies:
                         - RDPS.PRES_WD.400
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_400
                 - WIND_ISBL_400
@@ -3845,29 +2909,20 @@ model_gem_regional:
             elevation: 450mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.450:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.450:
                     dependencies:
                         - RDPS.PRES_WD.450
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_450
                 - WIND_ISBL_450
@@ -3876,29 +2931,20 @@ model_gem_regional:
             elevation: 500mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.500:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.500:
                     dependencies:
                         - RDPS.PRES_WD.500
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_500
                 - WIND_ISBL_500
@@ -3907,29 +2953,20 @@ model_gem_regional:
             elevation: 550mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.550:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.550:
                     dependencies:
                         - RDPS.PRES_WD.550
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_550
                 - WIND_ISBL_550
@@ -3938,29 +2975,20 @@ model_gem_regional:
             elevation: 600mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.600:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.600:
                     dependencies:
                         - RDPS.PRES_WD.600
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_600
                 - WIND_ISBL_600
@@ -3969,29 +2997,20 @@ model_gem_regional:
             elevation: 650mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.650:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.650:
                     dependencies:
                         - RDPS.PRES_WD.650
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_650
                 - WIND_ISBL_650
@@ -4000,29 +3019,20 @@ model_gem_regional:
             elevation: 700mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.700:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.700:
                     dependencies:
                         - RDPS.PRES_WD.700
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_700
                 - WIND_ISBL_700
@@ -4031,21 +3041,16 @@ model_gem_regional:
             elevation: 750mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.750:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.750:
                     dependencies:
                         - RDPS.PRES_WD.750
@@ -4062,29 +3067,20 @@ model_gem_regional:
             elevation: 800mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.800:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.800:
                     dependencies:
                         - RDPS.PRES_WD.800
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_800
                 - WIND_ISBL_800
@@ -4093,29 +3089,20 @@ model_gem_regional:
             elevation: 850mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.850:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.850:
                     dependencies:
                         - RDPS.PRES_WD.850
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_850
                 - WIND_ISBL_850
@@ -4124,29 +3111,20 @@ model_gem_regional:
             elevation: 875mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.875:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.875:
                     dependencies:
                         - RDPS.PRES_WD.875
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_875
                 - WIND_ISBL_875
@@ -4155,29 +3133,20 @@ model_gem_regional:
             elevation: 900mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.900:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.900:
                     dependencies:
                         - RDPS.PRES_WD.900
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_900
                 - WIND_ISBL_900
@@ -4186,29 +3155,20 @@ model_gem_regional:
             elevation: 925mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.925:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.925:
                     dependencies:
                         - RDPS.PRES_WD.925
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_925
                 - WIND_ISBL_925
@@ -4217,29 +3177,20 @@ model_gem_regional:
             elevation: 950mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.950:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.950:
                     dependencies:
                         - RDPS.PRES_WD.950
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_950
                 - WIND_ISBL_950
@@ -4248,29 +3199,20 @@ model_gem_regional:
             elevation: 970mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.970:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.970:
                     dependencies:
                         - RDPS.PRES_WD.970
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_970
                 - WIND_ISBL_970
@@ -4279,29 +3221,20 @@ model_gem_regional:
             elevation: 985mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.985:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.985:
                     dependencies:
                         - RDPS.PRES_WD.985
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_985
                 - WIND_ISBL_985
@@ -4310,29 +3243,20 @@ model_gem_regional:
             elevation: 1000mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.1000:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.1000:
                     dependencies:
                         - RDPS.PRES_WD.1000
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_1000
                 - WIND_ISBL_1000
@@ -4341,29 +3265,20 @@ model_gem_regional:
             elevation: 1015mb
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.PRES_WSPD.1015:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.PRES_UU.1015:
                     dependencies:
                         - RDPS.PRES_WD.1015
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_ISBL_1015
                 - WIND_ISBL_1015
@@ -4372,29 +3287,20 @@ model_gem_regional:
             elevation: 10m
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.ETA_WSPD:
-                    published: False
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
                 RDPS.ETA_UU:
                     dependencies:
                         - RDPS.ETA_WD
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
             bands_order:
                 - WDIR_TGL_10
                 - WIND_TGL_10
@@ -4403,986 +3309,778 @@ model_gem_regional:
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 48
+                    files_expected: 84
                 06Z:
-                    files_expected: 54
+                    files_expected: 84
                 12Z:
-                    files_expected: 48
+                    files_expected: 84
                 18Z:
-                    files_expected: 54
+                    files_expected: 84
             geomet_layers:
                 RDPS.ETA_FR:
-                    forecast_hours:
-                        00Z: 001/048/PT1H
-                        06Z: 001/054/PT1H
-                        12Z: 001/048/PT1H
-                        18Z: 001/054/PT1H
+                    forecast_hours: 001/084/PT1H
         APCP_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 48
+                    files_expected: 84
                 06Z:
-                    files_expected: 54
+                    files_expected: 84
                 12Z:
-                    files_expected: 48
+                    files_expected: 84
                 18Z:
-                    files_expected: 54
+                    files_expected: 84
             geomet_layers:
                 RDPS.ETA_PR:
-                    forecast_hours:
-                        00Z: 001/048/PT1H
-                        06Z: 001/054/PT1H
-                        12Z: 001/048/PT1H
-                        18Z: 001/054/PT1H
+                    forecast_hours: 001/084/PT1H
         WEARN_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 48
+                    files_expected: 84
                 06Z:
-                    files_expected: 54
+                    files_expected: 84
                 12Z:
-                    files_expected: 48
+                    files_expected: 84
                 18Z:
-                    files_expected: 54
+                    files_expected: 84
             geomet_layers:
                 RDPS.ETA_RN:
-                    forecast_hours:
-                        00Z: 001/048/PT1H
-                        06Z: 001/054/PT1H
-                        12Z: 001/048/PT1H
-                        18Z: 001/054/PT1H
+                    forecast_hours: 001/084/PT1H
         WEASN_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 48
+                    files_expected: 84
                 06Z:
-                    files_expected: 54
+                    files_expected: 84
                 12Z:
-                    files_expected: 48
+                    files_expected: 84
                 18Z:
-                    files_expected: 54
+                    files_expected: 84
             geomet_layers:
                 RDPS.ETA_SN:
-                    forecast_hours:
-                        00Z: 001/048/PT1H
-                        06Z: 001/054/PT1H
-                        12Z: 001/048/PT1H
-                        18Z: 001/054/PT1H
+                    forecast_hours: 001/084/PT1H
         SNOD_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 49
+                    files_expected: 85
                 06Z:
-                    files_expected: 55
+                    files_expected: 85
                 12Z:
-                    files_expected: 49
+                    files_expected: 85
                 18Z:
-                    files_expected: 55
+                    files_expected: 85
             geomet_layers:
                 RDPS.ETA_SD:
-                    forecast_hours:
-                        00Z: 000/048/PT1H
-                        06Z: 000/054/PT1H
-                        12Z: 000/048/PT1H
-                        18Z: 000/054/PT1H
+                    forecast_hours: 000/084/PT1H
         MU-VT-LI_ISBL_500:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_MU-VT-LI.500:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         ML-VT-CAPE_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_MU-VT-CAPE:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         ML-VT-CIN_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_MU-VT-CIN:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         MU-PRC-HGT_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_MU-PRC-HGT:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         SFC-VT-CAPE_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_SFC-VT-CAPE:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         SFC-VT-CIN_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_SFC-VT-CIN:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         ML-PRC-DPT_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_ML-PRC-DPT:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         ML-PRC-TMP_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_ML-PRC-TMP:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         ML-VT-LFC-HGT_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_ML-VT-LFC-HGT:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         SFC-LCL-HGT_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_SFC-LCL-HGT:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         SFC-VT-LFC-HGT_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_SFC-VT-LFC-HGT:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         ML-VT-LI_ISBL_500:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_ML-VT-LI.500:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         ML-VT-LI_ISBL_400:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_ML-VT-LI.400:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         ML-VT-LI_ISBL_600:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_ML-VT-LI.600:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         ML-VT-LI_ISBL_650:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_ML-VT-LI.650:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         ML-VT-LI_ISBL_700:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_ML-VT-LI.700:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         ML-VT-LI_ISBL_800:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_ML-VT-LI.800:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         SFC-VT-LI_ISBL_500:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_SFC-VT-LI.500:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         MU-CAPE_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_MU-CAPE:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         ML-CAPE_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_ML-CAPE:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         MU-CIN_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_MU-CIN:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         ML-CIN_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_ML-CIN:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         ML-LFC-HGT_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_ML-LFC-HGT:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         SFC-LFC-HGT_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_SFC-LFC-HGT:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         MU-LI_ISBL_500:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_MU-LI.500:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         ML-LI_ISBL_500:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_ML-LI.500:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         ML-LI_ISBL_400:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_ML-LI.400:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         ML-LI_ISBL_600:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_ML-LI.600:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         ML-LI_ISBL_650:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_ML-LI.650:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         ML-LI_ISBL_700:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_ML-LI.700:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         ML-LI_ISBL_800:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_ML-LI.800:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         SFC-LI_ISBL_500:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_SFC-LI.500:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         VT-SHWINX_ISBL_500:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_VT-SHWINX.500:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         MU-LCL-HGT_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_MU-LCL-HGT:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         MU-VT-LFC-HGT_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_MU-VT-LFC-HGT:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         MU-LFC-HGT_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_MU-LFC-HGT:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         ML-VT-EL-HGT_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_ML-VT-EL-HGT:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         ML-EL-HGT_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_ML-EL-HGT:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         MU-VT-EL-HGT_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_MU-VT-EL-HGT:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         MU-EL-HGT_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_MU-EL-HGT:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         SFC-VT-EL-HGT_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_SFC-VT-EL-HGT:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         SFC-EL-HGT_SFC_0:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 17
+                    files_expected: 29
                 06Z:
-                    files_expected: 19
+                    files_expected: 29
                 12Z:
-                    files_expected: 17
+                    files_expected: 29
                 18Z:
-                    files_expected: 19
+                    files_expected: 29
             geomet_layers:
                 RDPS.CONV_SFC-EL-HGT:
-                    forecast_hours:
-                        00Z: 000/048/PT3H
-                        06Z: 000/054/PT3H
-                        12Z: 000/048/PT3H
-                        18Z: 000/054/PT3H
+                    forecast_hours: 000/084/PT3H
         SIGPTYPE_SFC_0_PT1H:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 48
+                    files_expected: 84
                 06Z:
-                    files_expected: 54
+                    files_expected: 84
                 12Z:
-                    files_expected: 48
+                    files_expected: 84
                 18Z:
-                    files_expected: 54
+                    files_expected: 84
             geomet_layers:
                 RDPS.DIAG_NW_PT1H:
-                    forecast_hours:
-                        00Z: 001/048/PT1H
-                        06Z: 001/054/PT1H
-                        12Z: 001/048/PT1H
-                        18Z: 001/054/PT1H
+                    forecast_hours: 001/084/PT1H
         SIGPTYPE_SFC_0_PT3H:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 16
+                    files_expected: 28
                 06Z:
-                    files_expected: 18
+                    files_expected: 28
                 12Z:
-                    files_expected: 16
+                    files_expected: 28
                 18Z:
-                    files_expected: 18
+                    files_expected: 28
             geomet_layers:
                 RDPS.DIAG_NW_PT3H:
-                    forecast_hours:
-                        00Z: 003/048/PT3H
-                        06Z: 003/054/PT3H
-                        12Z: 003/048/PT3H
-                        18Z: 003/054/PT3H
+                    forecast_hours: 003/084/PT3H
         SIGPTYPE_SFC_0_PT6H:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 8
+                    files_expected: 14
                 06Z:
-                    files_expected: 9
+                    files_expected: 14
                 12Z:
-                    files_expected: 8
+                    files_expected: 14
                 18Z:
-                    files_expected: 9
+                    files_expected: 14
             geomet_layers:
                 RDPS.DIAG_NW_PT12H:
-                    forecast_hours:
-                        00Z: 006/048/PT6H
-                        06Z: 006/054/PT6H
-                        12Z: 006/048/PT6H
-                        18Z: 006/054/PT6H
+                    forecast_hours: 006/084/PT6H
         SIGPTYPE_SFC_0_PT12H:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 7
+                    files_expected: 13
                 06Z:
-                    files_expected: 8
+                    files_expected: 13
                 12Z:
-                    files_expected: 7
+                    files_expected: 13
                 18Z:
-                    files_expected: 8
+                    files_expected: 13
             geomet_layers:
                 RDPS.DIAG_NW_PT12H:
-                    forecast_hours:
-                        00Z: 0012/048/PT12H
-                        06Z: 0012/054/PT12H
-                        12Z: 0012/048/PT12H
-                        18Z: 0012/054/PT12H
+                    forecast_hours: 012/084/PT12H
         SIGPTYPE_SFC_0_PT24H:
             members: null
             elevation: surface
             model_run:
                 00Z:
-                    files_expected: 5
+                    files_expected: 11
                 06Z:
-                    files_expected: 6
+                    files_expected: 11
                 12Z:
-                    files_expected: 5
+                    files_expected: 11
                 18Z:
-                    files_expected: 6
+                    files_expected: 11
             geomet_layers:
                 RDPS.DIAG_NW_PT24H:
-                    forecast_hours:
-                        00Z: 0024/048/PT24H
-                        06Z: 0024/054/PT24H
-                        12Z: 0024/048/PT24H
-                        18Z: 0024/054/PT24H
+                    forecast_hours: 024/084/PT24H

--- a/deploy/default/model_giops.yml
+++ b/deploy/default/model_giops.yml
@@ -688,12 +688,11 @@ model_giops:
                     12Z:
                         files_expected: 10
                 geomet_layers:
-                    OCEAN.GIOPS.3D_UUW2_X_{}:
-                        published: False
+                    OCEAN.GIOPS.3D_UU2W_X_{}:
                         forecast_hours: 024/240/PT24H
                     OCEAN.GIOPS.3D_UU2W_{}:
                         dependencies:
-                            - OCEAN.GIOPS.3D_UUW2_Y_{}
+                            - OCEAN.GIOPS.3D_UU2W_Y_{}
                         forecast_hours: 024/240/PT24H
                 bands_order:
                     - vozocrtx
@@ -857,12 +856,11 @@ model_giops:
                     12Z:
                         files_expected: 10
                 geomet_layers:
-                    OCEAN.GIOPS.3D_UUW2_Y_{}:
-                        published: False
+                    OCEAN.GIOPS.3D_UU2W_Y_{}:
                         forecast_hours: 024/240/PT24H
                     OCEAN.GIOPS.3D_UU2W_{}:
                         dependencies:
-                            - OCEAN.GIOPS.3D_UUW2_X_{}
+                            - OCEAN.GIOPS.3D_UU2W_X_{}
                         forecast_hours: 024/240/PT24H
                 bands_order:
                     - vozocrtx

--- a/deploy/default/model_riops.yml
+++ b/deploy/default/model_riops.yml
@@ -1,0 +1,1262 @@
+model_riops:
+    model: RIOPS
+    model_run_retention_hours: 96
+    model_run_interval_hours: 6
+    dimensions:
+        x: 1770
+        y: 1610
+    filename_pattern: '{YYYYMMDD_model_run}_MSC_RIOPS_{wx_variable}_{elevation}_PS5km_P{forecast_hour:n}.nc'
+    2D:
+        variable:
+            IICECONC:
+                members: null
+                elevation: surface
+                model_run:
+                    00Z:
+                        files_expected: 49
+                    06Z:
+                        files_expected: 49
+                    12Z:
+                        files_expected: 49
+                    18Z:
+                        files_expected: 49
+                geomet_layers:
+                    RIOPS_IICECONC_SFC:
+                        forecast_hours: 000/048/PT1H
+            IICEDIVERGENCE:
+                members: null
+                elevation: surface
+                model_run:
+                    00Z:
+                        files_expected: 49
+                    06Z:
+                        files_expected: 49
+                    12Z:
+                        files_expected: 49
+                    18Z:
+                        files_expected: 49
+                geomet_layers:
+                    RIOPS_IICEDIVERGENCE_SFC:
+                        forecast_hours: 000/048/PT1H
+            IICEPRESSURE:
+                members: null
+                elevation: surface
+                model_run:
+                    00Z:
+                        files_expected: 49
+                    06Z:
+                        files_expected: 49
+                    12Z:
+                        files_expected: 49
+                    18Z:
+                        files_expected: 49
+                geomet_layers:
+                    RIOPS_IICEPRESSURE_SFC:
+                        forecast_hours: 000/048/PT1H
+            IICESHEAR:
+                members: null
+                elevation: surface
+                model_run:
+                    00Z:
+                        files_expected: 49
+                    06Z:
+                        files_expected: 49
+                    12Z:
+                        files_expected: 49
+                    18Z:
+                        files_expected: 49
+                geomet_layers:
+                    RIOPS_IICESHEAR_SFC:
+                        forecast_hours: 000/048/PT1H
+            IICESTRENGTH:
+                members: null
+                elevation: surface
+                model_run:
+                    00Z:
+                        files_expected: 49
+                    06Z:
+                        files_expected: 49
+                    12Z:
+                        files_expected: 49
+                    18Z:
+                        files_expected: 49
+                geomet_layers:
+                    RIOPS_IICESTRENGTH_SFC:
+                        forecast_hours: 000/048/PT1H
+            IICESURFTEMP:
+                members: null
+                elevation: surface
+                model_run:
+                    00Z:
+                        files_expected: 49
+                    06Z:
+                        files_expected: 49
+                    12Z:
+                        files_expected: 49
+                    18Z:
+                        files_expected: 49
+                geomet_layers:
+                    RIOPS_IICESURFTEMP_SFC:
+                        forecast_hours: 000/048/PT1H
+            IICEVOL:
+                members: null
+                elevation: surface
+                model_run:
+                    00Z:
+                        files_expected: 49
+                    06Z:
+                        files_expected: 49
+                    12Z:
+                        files_expected: 49
+                    18Z:
+                        files_expected: 49
+                geomet_layers:
+                    RIOPS_IICEVOL_SFC:
+                        forecast_hours: 000/048/PT1H
+            ISNOWVOL:
+                members: null
+                elevation: surface
+                model_run:
+                    00Z:
+                        files_expected: 49
+                    06Z:
+                        files_expected: 49
+                    12Z:
+                        files_expected: 49
+                    18Z:
+                        files_expected: 49
+                geomet_layers:
+                    RIOPS_ISNOWVOL_SFC:
+                        forecast_hours: 000/048/PT1H
+            ITMECRTY:
+                members: null
+                elevation: surface
+                model_run:
+                    00Z:
+                        files_expected: 49
+                    06Z:
+                        files_expected: 49
+                    12Z:
+                        files_expected: 49
+                    18Z:
+                        files_expected: 49
+                geomet_layers:
+                    RIOPS_UUY_SFC:
+                        forecast_hours: 000/048/PT1H
+                    RIOPS_UUI_SFC:
+                        dependencies:
+                            - RIOPS_UUX_SFC
+                        forecast_hours: 000/048/PT1H
+                bands_order:
+                    - ITZOCRTX
+                    - ITMECRTY
+            ITZOCRTX:
+                members: null
+                elevation: surface
+                model_run:
+                    00Z:
+                        files_expected: 49
+                    06Z:
+                        files_expected: 49
+                    12Z:
+                        files_expected: 49
+                    18Z:
+                        files_expected: 49
+                geomet_layers:
+                    RIOPS_UUX_SFC:
+                        forecast_hours: 000/048/PT1H
+                    RIOPS_UUI_SFC:
+                        dependencies:
+                            - RIOPS_UUY_SFC
+                        forecast_hours: 000/048/PT1H
+                bands_order:
+                    - ITZOCRTX
+                    - ITMECRTY
+            SOKARAML:
+                members: null
+                elevation: surface
+                model_run:
+                    00Z:
+                        files_expected: 49
+                    06Z:
+                        files_expected: 49
+                    12Z:
+                        files_expected: 49
+                    18Z:
+                        files_expected: 49
+                geomet_layers:
+                    RIOPS_SOKARAML_SFC:
+                        forecast_hours: 000/048/PT1H
+            SOMIXHGT:
+                members: null
+                elevation: surface
+                model_run:
+                    00Z:
+                        files_expected: 49
+                    06Z:
+                        files_expected: 49
+                    12Z:
+                        files_expected: 49
+                    18Z:
+                        files_expected: 49
+                geomet_layers:
+                    RIOPS_SOMIXHGT_SFC:
+                        forecast_hours: 000/048/PT1H
+            SOSSHEIG:
+                members: null
+                elevation: surface
+                model_run:
+                    00Z:
+                        files_expected: 49
+                    06Z:
+                        files_expected: 49
+                    12Z:
+                        files_expected: 49
+                    18Z:
+                        files_expected: 49
+                geomet_layers:
+                    RIOPS_SOSSHEIG_SFC:
+                        forecast_hours: 000/048/PT1H
+            VOMECRTY:
+                members: null
+                elevation: surface
+                model_run:
+                    00Z:
+                        files_expected: 49
+                    06Z:
+                        files_expected: 49
+                    12Z:
+                        files_expected: 49
+                    18Z:
+                        files_expected: 49
+                geomet_layers:
+                    RIOPS_UU2W_Y_DBS-0.5m:
+                        forecast_hours: 000/048/PT1H
+                    RIOPS_UU2W_DBS-0.5m:
+                        dependencies:
+                            - RIOPS_UU2W_X_DBS-0.5m
+                        forecast_hours: 000/048/PT1H
+                bands_order:
+                    - VOZOCRTX
+                    - VOMECRTY
+            VOSALINE:
+                members: null
+                elevation: surface
+                model_run:
+                    00Z:
+                        files_expected: 49
+                    06Z:
+                        files_expected: 49
+                    12Z:
+                        files_expected: 49
+                    18Z:
+                        files_expected: 49
+                geomet_layers:
+                    RIOPS_VOSALINE_DBS-0.5m:
+                        forecast_hours: 000/048/PT1H
+            VOTEMPER:
+                members: null
+                elevation: surface
+                model_run:
+                    00Z:
+                        files_expected: 49
+                    06Z:
+                        files_expected: 49
+                    12Z:
+                        files_expected: 49
+                    18Z:
+                        files_expected: 49
+                geomet_layers:
+                    RIOPS_VOTEMPER_DBS-0.5m:
+                        forecast_hours: 000/048/PT1H
+            VOZOCRTX:
+                members: null
+                elevation: surface
+                model_run:
+                    00Z:
+                        files_expected: 49
+                    06Z:
+                        files_expected: 49
+                    12Z:
+                        files_expected: 49
+                    18Z:
+                        files_expected: 49
+                geomet_layers:
+                    RIOPS_UU2W_X_DBS-0.5m:
+                        forecast_hours: 000/048/PT1H
+                    RIOPS_UU2W_DBS-0.5m:
+                        dependencies:
+                            - RIOPS_UU2W_Y_DBS-0.5m
+                        forecast_hours: 000/048/PT1H
+                bands_order:
+                    - VOZOCRTX
+                    - VOMECRTY
+    3D:
+        variable:
+            VOMECRTY:
+                bands:
+                    # band 1 is the same as the surface variable in 2D
+                    2:
+                        product: '1.6m'
+                        elevation: -1.6m
+                    3:
+                        product: '2.7m'
+                        elevation: -2.7m
+                    4:
+                        product: '3.9m'
+                        elevation: -3.9m
+                    5:
+                        product: '5.1m'
+                        elevation: -5.1m
+                    6:
+                        product: '6.5m'
+                        elevation: -6.5m
+                    7:
+                        product: '8.1m'
+                        elevation: -8.1m
+                    8:
+                        product: '-9.8m'
+                        elevation: -9.8m
+                    9:
+                        product: '12m'
+                        elevation: -12m
+                    10:
+                        product: '14m'
+                        elevation: -14m
+                    11:
+                        product: '17m'
+                        elevation: -17m
+                    12:
+                        product: '19m'
+                        elevation: -19m
+                    13:
+                        product: '23m'
+                        elevation: -23m
+                    14:
+                        product: '27m'
+                        elevation: -27m
+                    15:
+                        product: '31m'
+                        elevation: -31m
+                    16:
+                        product: '36m'
+                        elevation: -36m
+                    17:
+                        product: '41m'
+                        elevation: -41m
+                    18:
+                        product: '47m'
+                        elevation: -47m
+                    19:
+                        product: '54m'
+                        elevation: -54m
+                    20:
+                        product: '61m'
+                        elevation: -61m
+                    21:
+                        product: '69m'
+                        elevation: -69m
+                    22:
+                        product: '78m'
+                        elevation: -78m
+                    23:
+                        product: '87m'
+                        elevation: -87m
+                    24:
+                        product: '97m'
+                        elevation: -97m
+                    25:
+                        product: '108m'
+                        elevation: -108m
+                    26:
+                        product: '120m'
+                        elevation: -120m
+                    27:
+                        product: '133m'
+                        elevation: -133m
+                    28:
+                        product: '147m'
+                        elevation: -147m
+                    29:
+                        product: '163m'
+                        elevation: -163m
+                    30:
+                        product: '181m'
+                        elevation: -181m
+                    31:
+                        product: '200m'
+                        elevation: -200m
+                    32:
+                        product: '221m'
+                        elevation: -221m
+                    33:
+                        product: '245m'
+                        elevation: -243m
+                    34:
+                        product: '271m'
+                        elevation: -271m
+                    35:
+                        product: '301m'
+                        elevation: -301m
+                    36:
+                        product: '334m'
+                        elevation: -334m
+                    37:
+                        product: '371m'
+                        elevation: -371m
+                    38:
+                        product: '412m'
+                        elevation: -412m
+                    39:
+                        product: '458m'
+                        elevation: -458m
+                    40:
+                        product: '509m'
+                        elevation: -509m
+                    41:
+                        product: '565m'
+                        elevation: -0565m
+                    42:
+                        product: '628m'
+                        elevation: -628m
+                    43:
+                        product: '697m'
+                        elevation: -697m
+                    44:
+                        product: '773m'
+                        elevation: -773m
+                    45:
+                        product: '857m'
+                        elevation: -857m
+                    46:
+                        product: '947m'
+                        elevation: -947m
+                    47:
+                        product: '1046m'
+                        elevation: -1046m
+                    48:
+                        product: '1152m'
+                        elevation: -1152m
+                    49:
+                        product: '1266m'
+                        elevation: -1266m
+                    50:
+                        product: '1387m'
+                        elevation: -1387m
+                    51:
+                        product: '1516m'
+                        elevation: -1516m
+                    52:
+                        product: '1653m'
+                        elevation: -1653m
+                    53:
+                        product: '1796m'
+                        elevation: -1796m
+                    54:
+                        product: '1945m'
+                        elevation: -1945m
+                    55:
+                        product: '2101m'
+                        elevation: -2101m
+                    56:
+                        product: '2262m'
+                        elevation: -2262m
+                    57:
+                        product: '2429m'
+                        elevation: -2429m
+                    58:
+                        product: '2600m'
+                        elevation: -2600m
+                    59:
+                        product: '2776m'
+                        elevation: -2776m
+                    60:
+                        product: '2956m'
+                        elevation: -2956m
+                    61:
+                        product: '3139m'
+                        elevation: -3139m
+                    62:
+                        product: '3325m'
+                        elevation: -3325m
+                    63:
+                        product: '3513m'
+                        elevation: -3513m
+                    64:
+                        product: '3705m'
+                        elevation: -3705m
+                    65:
+                        product: '3898m'
+                        elevation: -3898m
+                    66:
+                        product: '4093m'
+                        elevation: -4093m
+                    67:
+                        product: '4290m'
+                        elevation: -4290m
+                    68:
+                        product: '4488m'
+                        elevation: -4488m
+                    69:
+                        product: '4688m'
+                        elevation: -4688m
+                    70:
+                        product: '4888m'
+                        elevation: -4888m
+                    71:
+                        product: '5089m'
+                        elevation: -5089m
+                    72:
+                        product: '5292m'
+                        elevation: -5292m
+                    73:
+                        product: '5495m'
+                        elevation: -5495m
+                    74:
+                        product: '5698m'
+                        elevation: -5698m
+                    75:
+                        product: '5902m'
+                        elevation: -5902m
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 49
+                    06Z:
+                        files_expected: 49
+                    12Z:
+                        files_expected: 49
+                    18Z:
+                        files_expected: 49
+                geomet_layers:
+                    RIOPS_UU2W_Y_DBS-{}:
+                        forecast_hours: 000/048/PT1H
+                    RIOPS_UU2W_DBS-{}:
+                        dependencies:
+                            -  RIOPS_UU2W_X_DBS-{}
+                        forecast_hours: 000/048/PT1H
+                bands_order:
+                    - VOZOCRTX
+                    - VOMECRTY
+            VOSALINE:
+                bands:
+                    # band 1 is the same as the surface variable in 2D
+                    2:
+                        product: '1.6m'
+                        elevation: -1.6m
+                    3:
+                        product: '2.7m'
+                        elevation: -2.7m
+                    4:
+                        product: '3.9m'
+                        elevation: -3.9m
+                    5:
+                        product: '5.1m'
+                        elevation: -5.1m
+                    6:
+                        product: '6.5m'
+                        elevation: -6.5m
+                    7:
+                        product: '8.1m'
+                        elevation: -8.1m
+                    8:
+                        product: '-9.8m'
+                        elevation: -9.8m
+                    9:
+                        product: '12m'
+                        elevation: -12m
+                    10:
+                        product: '14m'
+                        elevation: -14m
+                    11:
+                        product: '17m'
+                        elevation: -17m
+                    12:
+                        product: '19m'
+                        elevation: -19m
+                    13:
+                        product: '23m'
+                        elevation: -23m
+                    14:
+                        product: '27m'
+                        elevation: -27m
+                    15:
+                        product: '31m'
+                        elevation: -31m
+                    16:
+                        product: '36m'
+                        elevation: -36m
+                    17:
+                        product: '41m'
+                        elevation: -41m
+                    18:
+                        product: '47m'
+                        elevation: -47m
+                    19:
+                        product: '54m'
+                        elevation: -54m
+                    20:
+                        product: '61m'
+                        elevation: -61m
+                    21:
+                        product: '69m'
+                        elevation: -69m
+                    22:
+                        product: '78m'
+                        elevation: -78m
+                    23:
+                        product: '87m'
+                        elevation: -87m
+                    24:
+                        product: '97m'
+                        elevation: -97m
+                    25:
+                        product: '108m'
+                        elevation: -108m
+                    26:
+                        product: '120m'
+                        elevation: -120m
+                    27:
+                        product: '133m'
+                        elevation: -133m
+                    28:
+                        product: '147m'
+                        elevation: -147m
+                    29:
+                        product: '163m'
+                        elevation: -163m
+                    30:
+                        product: '181m'
+                        elevation: -181m
+                    31:
+                        product: '200m'
+                        elevation: -200m
+                    32:
+                        product: '221m'
+                        elevation: -221m
+                    33:
+                        product: '245m'
+                        elevation: -243m
+                    34:
+                        product: '271m'
+                        elevation: -271m
+                    35:
+                        product: '301m'
+                        elevation: -301m
+                    36:
+                        product: '334m'
+                        elevation: -334m
+                    37:
+                        product: '371m'
+                        elevation: -371m
+                    38:
+                        product: '412m'
+                        elevation: -412m
+                    39:
+                        product: '458m'
+                        elevation: -458m
+                    40:
+                        product: '509m'
+                        elevation: -509m
+                    41:
+                        product: '565m'
+                        elevation: -0565m
+                    42:
+                        product: '628m'
+                        elevation: -628m
+                    43:
+                        product: '697m'
+                        elevation: -697m
+                    44:
+                        product: '773m'
+                        elevation: -773m
+                    45:
+                        product: '857m'
+                        elevation: -857m
+                    46:
+                        product: '947m'
+                        elevation: -947m
+                    47:
+                        product: '1046m'
+                        elevation: -1046m
+                    48:
+                        product: '1152m'
+                        elevation: -1152m
+                    49:
+                        product: '1266m'
+                        elevation: -1266m
+                    50:
+                        product: '1387m'
+                        elevation: -1387m
+                    51:
+                        product: '1516m'
+                        elevation: -1516m
+                    52:
+                        product: '1653m'
+                        elevation: -1653m
+                    53:
+                        product: '1796m'
+                        elevation: -1796m
+                    54:
+                        product: '1945m'
+                        elevation: -1945m
+                    55:
+                        product: '2101m'
+                        elevation: -2101m
+                    56:
+                        product: '2262m'
+                        elevation: -2262m
+                    57:
+                        product: '2429m'
+                        elevation: -2429m
+                    58:
+                        product: '2600m'
+                        elevation: -2600m
+                    59:
+                        product: '2776m'
+                        elevation: -2776m
+                    60:
+                        product: '2956m'
+                        elevation: -2956m
+                    61:
+                        product: '3139m'
+                        elevation: -3139m
+                    62:
+                        product: '3325m'
+                        elevation: -3325m
+                    63:
+                        product: '3513m'
+                        elevation: -3513m
+                    64:
+                        product: '3705m'
+                        elevation: -3705m
+                    65:
+                        product: '3898m'
+                        elevation: -3898m
+                    66:
+                        product: '4093m'
+                        elevation: -4093m
+                    67:
+                        product: '4290m'
+                        elevation: -4290m
+                    68:
+                        product: '4488m'
+                        elevation: -4488m
+                    69:
+                        product: '4688m'
+                        elevation: -4688m
+                    70:
+                        product: '4888m'
+                        elevation: -4888m
+                    71:
+                        product: '5089m'
+                        elevation: -5089m
+                    72:
+                        product: '5292m'
+                        elevation: -5292m
+                    73:
+                        product: '5495m'
+                        elevation: -5495m
+                    74:
+                        product: '5698m'
+                        elevation: -5698m
+                    75:
+                        product: '5902m'
+                        elevation: -5902m
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 49
+                    06Z:
+                        files_expected: 49
+                    12Z:
+                        files_expected: 49
+                    18Z:
+                        files_expected: 49
+                geomet_layers:
+                    RIOPS_VOSALINE_DBS-{}:
+                        forecast_hours: 000/048/PT1H
+            VOTEMPER:
+                bands:
+                bands:
+                    # band 1 is the same as the surface variable in 2D
+                    2:
+                        product: '1.6m'
+                        elevation: -1.6m
+                    3:
+                        product: '2.7m'
+                        elevation: -2.7m
+                    4:
+                        product: '3.9m'
+                        elevation: -3.9m
+                    5:
+                        product: '5.1m'
+                        elevation: -5.1m
+                    6:
+                        product: '6.5m'
+                        elevation: -6.5m
+                    7:
+                        product: '8.1m'
+                        elevation: -8.1m
+                    8:
+                        product: '-9.8m'
+                        elevation: -9.8m
+                    9:
+                        product: '12m'
+                        elevation: -12m
+                    10:
+                        product: '14m'
+                        elevation: -14m
+                    11:
+                        product: '17m'
+                        elevation: -17m
+                    12:
+                        product: '19m'
+                        elevation: -19m
+                    13:
+                        product: '23m'
+                        elevation: -23m
+                    14:
+                        product: '27m'
+                        elevation: -27m
+                    15:
+                        product: '31m'
+                        elevation: -31m
+                    16:
+                        product: '36m'
+                        elevation: -36m
+                    17:
+                        product: '41m'
+                        elevation: -41m
+                    18:
+                        product: '47m'
+                        elevation: -47m
+                    19:
+                        product: '54m'
+                        elevation: -54m
+                    20:
+                        product: '61m'
+                        elevation: -61m
+                    21:
+                        product: '69m'
+                        elevation: -69m
+                    22:
+                        product: '78m'
+                        elevation: -78m
+                    23:
+                        product: '87m'
+                        elevation: -87m
+                    24:
+                        product: '97m'
+                        elevation: -97m
+                    25:
+                        product: '108m'
+                        elevation: -108m
+                    26:
+                        product: '120m'
+                        elevation: -120m
+                    27:
+                        product: '133m'
+                        elevation: -133m
+                    28:
+                        product: '147m'
+                        elevation: -147m
+                    29:
+                        product: '163m'
+                        elevation: -163m
+                    30:
+                        product: '181m'
+                        elevation: -181m
+                    31:
+                        product: '200m'
+                        elevation: -200m
+                    32:
+                        product: '221m'
+                        elevation: -221m
+                    33:
+                        product: '245m'
+                        elevation: -243m
+                    34:
+                        product: '271m'
+                        elevation: -271m
+                    35:
+                        product: '301m'
+                        elevation: -301m
+                    36:
+                        product: '334m'
+                        elevation: -334m
+                    37:
+                        product: '371m'
+                        elevation: -371m
+                    38:
+                        product: '412m'
+                        elevation: -412m
+                    39:
+                        product: '458m'
+                        elevation: -458m
+                    40:
+                        product: '509m'
+                        elevation: -509m
+                    41:
+                        product: '565m'
+                        elevation: -0565m
+                    42:
+                        product: '628m'
+                        elevation: -628m
+                    43:
+                        product: '697m'
+                        elevation: -697m
+                    44:
+                        product: '773m'
+                        elevation: -773m
+                    45:
+                        product: '857m'
+                        elevation: -857m
+                    46:
+                        product: '947m'
+                        elevation: -947m
+                    47:
+                        product: '1046m'
+                        elevation: -1046m
+                    48:
+                        product: '1152m'
+                        elevation: -1152m
+                    49:
+                        product: '1266m'
+                        elevation: -1266m
+                    50:
+                        product: '1387m'
+                        elevation: -1387m
+                    51:
+                        product: '1516m'
+                        elevation: -1516m
+                    52:
+                        product: '1653m'
+                        elevation: -1653m
+                    53:
+                        product: '1796m'
+                        elevation: -1796m
+                    54:
+                        product: '1945m'
+                        elevation: -1945m
+                    55:
+                        product: '2101m'
+                        elevation: -2101m
+                    56:
+                        product: '2262m'
+                        elevation: -2262m
+                    57:
+                        product: '2429m'
+                        elevation: -2429m
+                    58:
+                        product: '2600m'
+                        elevation: -2600m
+                    59:
+                        product: '2776m'
+                        elevation: -2776m
+                    60:
+                        product: '2956m'
+                        elevation: -2956m
+                    61:
+                        product: '3139m'
+                        elevation: -3139m
+                    62:
+                        product: '3325m'
+                        elevation: -3325m
+                    63:
+                        product: '3513m'
+                        elevation: -3513m
+                    64:
+                        product: '3705m'
+                        elevation: -3705m
+                    65:
+                        product: '3898m'
+                        elevation: -3898m
+                    66:
+                        product: '4093m'
+                        elevation: -4093m
+                    67:
+                        product: '4290m'
+                        elevation: -4290m
+                    68:
+                        product: '4488m'
+                        elevation: -4488m
+                    69:
+                        product: '4688m'
+                        elevation: -4688m
+                    70:
+                        product: '4888m'
+                        elevation: -4888m
+                    71:
+                        product: '5089m'
+                        elevation: -5089m
+                    72:
+                        product: '5292m'
+                        elevation: -5292m
+                    73:
+                        product: '5495m'
+                        elevation: -5495m
+                    74:
+                        product: '5698m'
+                        elevation: -5698m
+                    75:
+                        product: '5902m'
+                        elevation: -5902m
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 49
+                    06Z:
+                        files_expected: 49
+                    12Z:
+                        files_expected: 49
+                    18Z:
+                        files_expected: 49
+                geomet_layers:
+                    RIOPS_VOTEMPER_DBS-{}:
+                        forecast_hours: 000/048/PT1H
+            VOZOCRTX:
+                bands:
+                    # band 1 is the same as the surface variable in 2D
+                    2:
+                        product: '1.6m'
+                        elevation: -1.6m
+                    3:
+                        product: '2.7m'
+                        elevation: -2.7m
+                    4:
+                        product: '3.9m'
+                        elevation: -3.9m
+                    5:
+                        product: '5.1m'
+                        elevation: -5.1m
+                    6:
+                        product: '6.5m'
+                        elevation: -6.5m
+                    7:
+                        product: '8.1m'
+                        elevation: -8.1m
+                    8:
+                        product: '-9.8m'
+                        elevation: -9.8m
+                    9:
+                        product: '12m'
+                        elevation: -12m
+                    10:
+                        product: '14m'
+                        elevation: -14m
+                    11:
+                        product: '17m'
+                        elevation: -17m
+                    12:
+                        product: '19m'
+                        elevation: -19m
+                    13:
+                        product: '23m'
+                        elevation: -23m
+                    14:
+                        product: '27m'
+                        elevation: -27m
+                    15:
+                        product: '31m'
+                        elevation: -31m
+                    16:
+                        product: '36m'
+                        elevation: -36m
+                    17:
+                        product: '41m'
+                        elevation: -41m
+                    18:
+                        product: '47m'
+                        elevation: -47m
+                    19:
+                        product: '54m'
+                        elevation: -54m
+                    20:
+                        product: '61m'
+                        elevation: -61m
+                    21:
+                        product: '69m'
+                        elevation: -69m
+                    22:
+                        product: '78m'
+                        elevation: -78m
+                    23:
+                        product: '87m'
+                        elevation: -87m
+                    24:
+                        product: '97m'
+                        elevation: -97m
+                    25:
+                        product: '108m'
+                        elevation: -108m
+                    26:
+                        product: '120m'
+                        elevation: -120m
+                    27:
+                        product: '133m'
+                        elevation: -133m
+                    28:
+                        product: '147m'
+                        elevation: -147m
+                    29:
+                        product: '163m'
+                        elevation: -163m
+                    30:
+                        product: '181m'
+                        elevation: -181m
+                    31:
+                        product: '200m'
+                        elevation: -200m
+                    32:
+                        product: '221m'
+                        elevation: -221m
+                    33:
+                        product: '245m'
+                        elevation: -243m
+                    34:
+                        product: '271m'
+                        elevation: -271m
+                    35:
+                        product: '301m'
+                        elevation: -301m
+                    36:
+                        product: '334m'
+                        elevation: -334m
+                    37:
+                        product: '371m'
+                        elevation: -371m
+                    38:
+                        product: '412m'
+                        elevation: -412m
+                    39:
+                        product: '458m'
+                        elevation: -458m
+                    40:
+                        product: '509m'
+                        elevation: -509m
+                    41:
+                        product: '565m'
+                        elevation: -0565m
+                    42:
+                        product: '628m'
+                        elevation: -628m
+                    43:
+                        product: '697m'
+                        elevation: -697m
+                    44:
+                        product: '773m'
+                        elevation: -773m
+                    45:
+                        product: '857m'
+                        elevation: -857m
+                    46:
+                        product: '947m'
+                        elevation: -947m
+                    47:
+                        product: '1046m'
+                        elevation: -1046m
+                    48:
+                        product: '1152m'
+                        elevation: -1152m
+                    49:
+                        product: '1266m'
+                        elevation: -1266m
+                    50:
+                        product: '1387m'
+                        elevation: -1387m
+                    51:
+                        product: '1516m'
+                        elevation: -1516m
+                    52:
+                        product: '1653m'
+                        elevation: -1653m
+                    53:
+                        product: '1796m'
+                        elevation: -1796m
+                    54:
+                        product: '1945m'
+                        elevation: -1945m
+                    55:
+                        product: '2101m'
+                        elevation: -2101m
+                    56:
+                        product: '2262m'
+                        elevation: -2262m
+                    57:
+                        product: '2429m'
+                        elevation: -2429m
+                    58:
+                        product: '2600m'
+                        elevation: -2600m
+                    59:
+                        product: '2776m'
+                        elevation: -2776m
+                    60:
+                        product: '2956m'
+                        elevation: -2956m
+                    61:
+                        product: '3139m'
+                        elevation: -3139m
+                    62:
+                        product: '3325m'
+                        elevation: -3325m
+                    63:
+                        product: '3513m'
+                        elevation: -3513m
+                    64:
+                        product: '3705m'
+                        elevation: -3705m
+                    65:
+                        product: '3898m'
+                        elevation: -3898m
+                    66:
+                        product: '4093m'
+                        elevation: -4093m
+                    67:
+                        product: '4290m'
+                        elevation: -4290m
+                    68:
+                        product: '4488m'
+                        elevation: -4488m
+                    69:
+                        product: '4688m'
+                        elevation: -4688m
+                    70:
+                        product: '4888m'
+                        elevation: -4888m
+                    71:
+                        product: '5089m'
+                        elevation: -5089m
+                    72:
+                        product: '5292m'
+                        elevation: -5292m
+                    73:
+                        product: '5495m'
+                        elevation: -5495m
+                    74:
+                        product: '5698m'
+                        elevation: -5698m
+                    75:
+                        product: '5902m'
+                        elevation: -5902m
+                members: null
+                model_run:
+                    00Z:
+                        files_expected: 49
+                    06Z:
+                        files_expected: 49
+                    12Z:
+                        files_expected: 49
+                    18Z:
+                        files_expected: 49
+                geomet_layers:
+                    RIOPS_UU2W_X_DBS-{}:
+                        forecast_hours: 000/048/PT1H
+                    RIOPS_UU2W_DBS-{}:
+                        dependencies:
+                            -  RIOPS_UU2W_Y_DBS-{}
+                        forecast_hours: 000/048/PT1H
+                bands_order:
+                    - VOZOCRTX
+                    - VOMECRTY

--- a/deploy/default/sarracenia/model_riops.conf
+++ b/deploy/default/sarracenia/model_riops.conf
@@ -1,0 +1,13 @@
+broker amqps://anonymous:anonymous@dd.weather.gc.ca/
+queue_name q_${BROKER_USER}.${PROGRAM}.${CONFIG}.${HOSTNAME}
+directory ${GDR_DATADIR}
+notify_only ${GDR_METPX_NOTIFY}
+instances 6
+subtopic model_riops.netcdf.forecast.polar_stereographic.#
+mirror True
+report_back False
+accept .*
+discard ${GDR_METPX_DISCARD}
+#on_file ${GDR_METPX_EVENT_PY}
+on_message ${GDR_METPX_EVENT_PY}
+chmod_log 0644

--- a/geomet_data_registry/layer/model_gem_regional.py
+++ b/geomet_data_registry/layer/model_gem_regional.py
@@ -115,7 +115,7 @@ class ModelGemRegionalLayer(BaseLayer):
         for layer_name, layer_config in self.geomet_layers.items():
             identifier = '{}-{}-{}'.format(layer_name, str_mr, str_fh)
 
-            forecast_hours = layer_config['forecast_hours'][self.model_run]
+            forecast_hours = layer_config['forecast_hours']
             begin, end, interval = [int(re.sub('[^0-9]', '', value))
                                     for value in forecast_hours.split('/')]
             fh = int(file_pattern_info['fh'])

--- a/geomet_data_registry/plugin.py
+++ b/geomet_data_registry/plugin.py
@@ -71,6 +71,10 @@ PLUGINS = {
             'pattern': 'CMC_giops*',
             'path': 'geomet_data_registry.layer.model_giops.GiopsLayer',
         },
+        'RIOPS': {
+            'pattern': '*MSC_RIOPS*',
+            'path': 'geomet_data_registry.layer.model_riops.RiopsLayer',
+        },
         'CGSL': {
             'pattern': 'CMC_coupled-rdps-stlawrence*',
             'path': 'geomet_data_registry.layer.cgsl.CgslLayer',


### PR DESCRIPTION
This MR contains the initial RIOPS layer handler and configuration.

It also contains the following model fixes/improvements:

- Modifies  `deploy/default/model_gem_regional.yml`  and `geomet_data_registry/layer/model_gem_regional.py` now that RDPS forecast hours now cover [84 hours for all model runs](https://lists.ec.gc.ca/pipermail/dd_info/2020-September/000412.html).
- Fixed typos in dependency names for `OCEAN.GIOPS.3D_UU2W_<depth>` layers in `deploy/default/model_giops.yml`.
- When iterating over bands, ensure a `deepcopy` of `weather_var['geomet_layers']` is made in order to avoid continuously modifying the same object in memory when iterating over each band in the GIOPS/RIOPS layer handlers.