### PR TITLE
fix cansips time extent date format

### DIFF
--- a/geomet_data_registry/layer/cansips.py
+++ b/geomet_data_registry/layer/cansips.py
@@ -173,7 +173,10 @@ class CansipsLayer(BaseLayer):
                 months=int(item['forecast_hours']['begin']))
             end_time = self.date_ + relativedelta(
                 months=int(item['forecast_hours']['end']))
+
+            start_time = start_time.strftime(DATE_FORMAT)
             end_time = end_time.strftime(DATE_FORMAT)
+
             time_extent_value = '{}/{}/{}'.format(start_time,
                                                   end_time,
                                                   item['forecast_hours']


### PR DESCRIPTION
Bug found by @PhilippeTh

The start date in the time extent for cansips was not formatted correctly.