### PR TITLE
update to giops to remove unused parsed information

### DIFF
--- a/deploy/default/model_giops.yml
+++ b/deploy/default/model_giops.yml
@@ -5,7 +5,7 @@ model_giops:
     dimensions:
         x: 1800
         y: 850
-    filename_pattern: CMC_giops_{wx_variable}_{fileinfo:parse_fileinfo}_{YYYYMMDD_model_run}_{forecast_hour_prefix:l}{forecast_hour:n}.nc
+    filename_pattern: CMC_giops_{wx_variable}_{fileinfo:parse_fileinfo}_{YYYYMMDD_model_run}_P{forecast_hour:n}.nc
     2D:
         variable:
             iiceconc:

--- a/geomet_data_registry/layer/model_giops.py
+++ b/geomet_data_registry/layer/model_giops.py
@@ -83,7 +83,6 @@ class GiopsLayer(BaseLayer):
         file_pattern_info = {
             'wx_variable': tmp.named['wx_variable'],
             'time_': tmp.named['YYYYMMDD_model_run'],
-            'forecast_hour_prefix': tmp.named['forecast_hour_prefix'],
             'fh': tmp.named['forecast_hour']
         }
 


### PR DESCRIPTION
update to giops to remove unused parsed information which is causing GDR to fail on GIOPS at the moment