### PR TITLE
remove redis-py deprecated charset argument

### DIFF
--- a/geomet_data_registry/store/redis_.py
+++ b/geomet_data_registry/store/redis_.py
@@ -43,7 +43,6 @@ class RedisStore(BaseStore):
 
         try:
             self.redis = redis.Redis.from_url(self.url,
-                                              charset='utf-8',
                                               decode_responses=True)
         except redis.exceptions.ConnectionError as err:
             msg = 'Cannot connect to Redis {}: {}'.format(self.url, err)


### PR DESCRIPTION
When installing GDR via docker (which automatically pulls the latest redis-py version `4.0.0rc1`, I was hit with an unexpected keyword argument error.

The `charset` keyword argument will be  removed in newer versions of redis-py. It is suggested to use the `encoding` keyword argument that already has a default value of  `utf-8`. See redis-py's [`redis.Connection()`](https://redis-py.readthedocs.io/en/stable/#redis.Connection) documentation for further details.

I have tested this change against redis-py `3.5.3` and `4.0.0rc1`, it will allow for a smoother transition down the line.